### PR TITLE
perform full "--as-cran" check of R-package

### DIFF
--- a/R-package/.R.travis.sh
+++ b/R-package/.R.travis.sh
@@ -52,9 +52,9 @@ R CMD check "${PKG_FILE_NAME}" --as-cran || exit -1
 if grep -q -R "WARNING" "$LOG_FILE_NAME"; then
     echo "WARNINGS have been found in the build log!"
     exit -1
-#elif grep -q -R "NOTE" "$LOG_FILE_NAME"; then
-#    echo "NOTES have been found in the build log!"
-#    exit -1
+elif grep -q -R "NOTE" "$LOG_FILE_NAME"; then
+    echo "NOTES have been found in the build log!"
+    exit -1
 fi
 
 Rscript -e 'covr::codecov(quiet = FALSE)'


### PR DESCRIPTION
Now `rgf/R-package` folder exists and we can catch **NOTE** in the log file too.

@mlampros I've just invited you to collaborate on RGF repository, please check your email. If @fukatani agree, I think we can include you in team members.

Also, I've created the PR to `mlampros/RGF` repo: https://github.com/mlampros/RGF/pull/4 with README update.