### PR TITLE
downgrade R min version

### DIFF
--- a/R-package/DESCRIPTION
+++ b/R-package/DESCRIPTION
@@ -11,7 +11,7 @@ Description: Regularized Greedy Forest wrapper of the 'Regularized Greedy Forest
 License: MIT + file LICENSE
 SystemRequirements: Python (2.7 or >= 3.4), rgf_python, scikit-learn (>= 0.18.0), scipy, numpy. Detailed installation instructions for each operating system can be found in the README file.
 Depends:
-    R(>= 3.2.3)
+    R(>= 3.1.0)
 Imports:
     reticulate, R6, Matrix
 Suggests:

--- a/R-package/NEWS.md
+++ b/R-package/NEWS.md
@@ -2,6 +2,8 @@
 
 The RGF R package was integrated in the home repository for the Regularized Greedy Forest (RGF) library (https://github.com/RGF-team).
 
+* We downgraded minimum required version of R to 3.1.0
+
 
 ## RGF 1.0.4
 


### PR DESCRIPTION
According to [this](https://github.com/RGF-team/rgf/pull/208#issuecomment-413357029) (RGF tests are passed with R 3.1.0) and [this](https://github.com/RGF-team/rgf/pull/208#issuecomment-413698083) (Matrix R package, which is a dependence of the RGF package, works fine with R 3.1.0) required R version can be downgraded to 3.1.0.