### PR TITLE
fix R environment at Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,8 +43,14 @@ before_install:
   - conda config --set always_yes yes --set changeps1 no
   - conda update -q conda
 
-  - conda create -q -n test-environment python=$PYTHON_VERSION numpy scipy nose pandas scikit-learn pytest
-  - source activate test-environment
+  - if [[ $TASK == "R_PACKAGE" ]]; then
+        conda create -q -n test-environment python=$PYTHON_VERSION pip openssl --no-deps;
+        source activate test-environment;
+        pip install setuptools wheel numpy scipy nose pandas scikit-learn pytest;
+    else
+        conda create -q -n test-environment python=$PYTHON_VERSION numpy scipy nose pandas scikit-learn pytest;
+        source activate test-environment;
+    fi
 
   - RGF_VER=$(head -n 1 python-package/rgf/VERSION)
 

--- a/R-package/.R.travis.sh
+++ b/R-package/.R.travis.sh
@@ -7,8 +7,6 @@ export PATH="$R_LIB_PATH/R/bin:$PATH"
 
 sudo apt-get install gfortran-5
 sudo update-alternatives --install /usr/bin/gfortran gfortran /usr/bin/gfortran-5 10
-# use system-wide libraries (fix error "symbol _ZTINSt8ios_base7failureB5cxx11E, version GLIBCXX_3.4.21 not defined in file libstdc++.so.6 with link time reference")
-conda remove --force libgfortran-ng libgcc-ng libstdcxx-ng
 
 # install packages to build and check documentation
 conda install --no-deps pandoc

--- a/R-package/README.md
+++ b/R-package/README.md
@@ -1,6 +1,6 @@
-[![CRAN_Status_Badge](https://r-pkg.org/badges/version/RGF)](https://cran.r-project.org/package=RGF)
-[![codecov.io](https://codecov.io/github/mlampros/RGF/coverage.svg?branch=master)](https://codecov.io/github/mlampros/RGF?branch=master)
-[![Downloads](https://cranlogs.r-pkg.org/badges/grand-total/RGF?color=blue)](https://cran.r-project.org/package=RGF)
+[![CRAN Version](https://r-pkg.org/badges/version/RGF)](https://cran.r-project.org/package=RGF)
+[![codecov.io](https://codecov.io/github/RGF-team/rgf/coverage.svg?branch=master)](https://codecov.io/github/RGF-team/rgf?branch=master)
+[![CRAN Downloads](https://cranlogs.r-pkg.org/badges/grand-total/RGF?color=blue)](https://cran.r-project.org/package=RGF)
 
 
 ## RGF (Regularized Greedy Forest)


### PR DESCRIPTION
While preparing #228 I've noticed that code coverage value was extremely small:
![image](https://user-images.githubusercontent.com/25141164/44476517-a4ee5280-a640-11e8-84ee-5f31b00bdb50.png)

I've dig deeper and it turned out that all this time tests hadn't been run due to this function:
https://github.com/RGF-team/rgf/blob/f47000c46e5346474f69e7cc96a936386da1094f/R-package/tests/testthat/test_package.R#L7

The reason was in that even after applying all my hotfixes in #208 scipy (or numpy) failed because of hard linking to conda's library, which conflicts with system-wide one. So, this PR solves this problem by installing PyPI versions of all packages.

While `R CMD check` is not verbose, but I needed any info why rgf module is not available, I managed to get useful logs by running `Rscript -e 'testthat::test_dir("./tests")'`.

In addition, even in this new clean environment and after improving the code coverage `test_dir` yields the following error/warning (I don't know what it is):
```
✔ | OK F W S | Context
Error in x[[method]](...) : attempt to apply non-function
Calls: <Anonymous> ... <Anonymous> -> o_apply -> lapply -> FUN -> <Anonymous>
══ Results ═════════════════════════════════════════════════════════════════════
OK:       0
Failed:   2
Warnings: 0
Skipped:  0
Execution halted
Warning: unknown option ‘--with-keep.parse.data’
```

My assumption is that RGF suffers from the following bug: https://github.com/r-lib/testthat/issues/700 . Ping @mlampros for the future investigation.