### PR TITLE
updated the tests file in R-package

### DIFF
--- a/R-package/DESCRIPTION
+++ b/R-package/DESCRIPTION
@@ -2,7 +2,7 @@ Package: RGF
 Type: Package
 Title: Regularized Greedy Forest
 Version: 1.0.5
-Date: 2018-08-15
+Date: 2018-08-23
 Authors@R: c( person("Lampros", "Mouselimis", email = "mouselimislampros@gmail.com", role = c("aut", "cre")), person("Ryosuke", "Fukatani", role = "cph", comment = "Author of the python wrapper of the 'Regularized Greedy Forest' machine learning algorithm"), person("Nikita", "Titov", role = "cph", comment = "Author of the python wrapper of the 'Regularized Greedy Forest' machine learning algorithm"), person("Tong", "Zhang", role = "cph", comment = "Author of the 'Regularized Greedy Forest' and of the Multi-core implementation of Regularized Greedy Forest machine learning algorithm"), person("Rie", "Johnson", role = "cph", comment = "Author of the 'Regularized Greedy Forest' machine learning algorithm") )
 Maintainer: Lampros Mouselimis <mouselimislampros@gmail.com>
 BugReports: https://github.com/RGF-team/rgf/issues

--- a/R-package/tests/testthat/test-RGF_package.R
+++ b/R-package/tests/testthat/test-RGF_package.R
@@ -1,3 +1,5 @@
+context('rgf R-package tests')
+
 #========================================================================================
 
 # helper function to skip tests if we don't have the 'foo' module


### PR DESCRIPTION
This pull request is a continuation of [#230](https://github.com/RGF-team/rgf/pull/230). In this PR I modified the initial test file in the following ways:

* I renamed the test file from *test_package.R* to *test-RGF_package.R*
* I added *context('rgf R-package tests')* at the top of the *test-RGF_package.R* as suggested in the [testthat documentation](http://r-pkgs.had.co.nz/tests.html#test-files)