### PR TITLE
[R-package] Replaced =F with =FALSE

### DIFF
--- a/R-package/R/utils.R
+++ b/R-package/R/utils.R
@@ -63,7 +63,7 @@ mat_2scipy_sparse = function(x, format = 'sparse_row_matrix') {
 
   } else {
 
-    stop("the function can take either a 'sparse_row_matrix' or a 'sparse_column_matrix' for the 'format' parameter as input", call. = F)
+    stop("the function can take either a 'sparse_row_matrix' or a 'sparse_column_matrix' for the 'format' parameter as input", call. = FALSE)
   }
 }
 
@@ -154,8 +154,7 @@ TO_scipy_sparse = function(R_sparse_matrix) {
   }
 
   else {
-
-    stop("the 'R_sparse_matrix' parameter should be either a 'dgCMatrix' or a 'dgRMatrix' sparse matrix", call. = F)
+    stop("the 'R_sparse_matrix' parameter should be either a 'dgCMatrix' or a 'dgRMatrix' sparse matrix", call. = FALSE)
   }
 
   return(py_obj)

--- a/R-package/tests/testthat/test-RGF_package.R
+++ b/R-package/tests/testthat/test-RGF_package.R
@@ -323,7 +323,7 @@ if (Sys.info()["sysname"] != 'Darwin') {
     skip_test_if_no_module(c("rgf.sklearn", 'scipy'))
   
     set.seed(1)
-    sap = sapply(1:1000, function(x) sample(c(0.0, runif(1)), 1, replace = F))            # create sparse data
+    sap = sapply(1:1000, function(x) sample(c(0.0, runif(1)), 1, replace = FALSE))            # create sparse data
   
     dgcM = Matrix::Matrix(data = sap,
   


### PR DESCRIPTION
Using `F` and `T` is not advisable in R code. `FALSE` is a protected keyword while `F` is just an alias for `FALSE`.

```{r}
# works
F <- 4
print(F)

# "Error in FALSE = 5 : invalid (do_set) left-hand side to assignment"
FALSE <- 4
```

Please consider this PR to change a few `F`s to `FALSE`