### PR TITLE
add build artifacts to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,15 @@
+
+# miscellaneous stuff
+.DS_Store
+*/.DS_Store
+
+# build artifacts
+CMakeCache.txt
+CMakeFiles/
+Makefile
+cmake_install.cmake
+
+# Python package stuff
 temp/
 *.pyc
 rgf_python.egg-info/
@@ -6,4 +18,11 @@ build/*
 python-package/include/rgf/bin/*
 python-package/include/fast_rgf/bin/*
 *.pkl
+python-package/build/
+python-package/compile/
+python-package/temp_*
 
+# R package stuff
+R-package/*.tar.gz
+*.tar.gz
+*.Rhistory

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-
 # miscellaneous stuff
 .DS_Store
 */.DS_Store


### PR DESCRIPTION
I built the R package on my MacOS machine tonight using the instructions [here](https://github.com/RGF-team/rgf/blob/master/R-package/README.md). After doing this, I found a lot of build artifacts left laying around. Please consider this PR to add them to the `.gitignore` so no one checks them into the repo accidentally.