### PR TITLE
removed makefile from gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,6 @@
 # build artifacts
 CMakeCache.txt
 CMakeFiles/
-Makefile
 cmake_install.cmake
 
 # Python package stuff


### PR DESCRIPTION
@jameslamb Sorry, I've forgotten that we distribute `makefile` for the RGF software:
https://github.com/RGF-team/rgf/blob/master/RGF/build/makefile

Hotfix after #242.