### PR TITLE
R package update to CRAN version 1.0.5

### DIFF
--- a/R-package/.R.travis.sh
+++ b/R-package/.R.travis.sh
@@ -47,9 +47,6 @@ R CMD check "${PKG_FILE_NAME}" --as-cran || exit -1
 if grep -q -R "WARNING" "$LOG_FILE_NAME"; then
     echo "WARNINGS have been found in the build log!"
     exit -1
-elif grep -q -R "NOTE" "$LOG_FILE_NAME"; then
-    echo "NOTES have been found in the build log!"
-    exit -1
 fi
 
 Rscript -e 'covr::codecov(quiet = FALSE)'

--- a/R-package/DESCRIPTION
+++ b/R-package/DESCRIPTION
@@ -2,7 +2,7 @@ Package: RGF
 Type: Package
 Title: Regularized Greedy Forest
 Version: 1.0.5
-Date: 2018-08-23
+Date: 2018-09-23
 Authors@R: c( person("Lampros", "Mouselimis", email = "mouselimislampros@gmail.com", role = c("aut", "cre")), person("Ryosuke", "Fukatani", role = "cph", comment = "Author of the python wrapper of the 'Regularized Greedy Forest' machine learning algorithm"), person("Nikita", "Titov", role = "cph", comment = "Author of the python wrapper of the 'Regularized Greedy Forest' machine learning algorithm"), person("Tong", "Zhang", role = "cph", comment = "Author of the 'Regularized Greedy Forest' and of the Multi-core implementation of Regularized Greedy Forest machine learning algorithm"), person("Rie", "Johnson", role = "cph", comment = "Author of the 'Regularized Greedy Forest' machine learning algorithm") )
 Maintainer: Lampros Mouselimis <mouselimislampros@gmail.com>
 BugReports: https://github.com/RGF-team/rgf/issues

--- a/R-package/NEWS.md
+++ b/R-package/NEWS.md
@@ -1,8 +1,9 @@
 ## RGF 1.0.5
 
-The RGF R package was integrated in the home repository for the Regularized Greedy Forest (RGF) library (https://github.com/RGF-team).
+The RGF R package was integrated in the home repository of the Regularized Greedy Forest (RGF) library (https://github.com/RGF-team).
 
-* We downgraded minimum required version of R to 3.2.0
+* We downgraded the minimum required version of R to 3.2.0
+* We modified / formatted the R files
 
 
 ## RGF 1.0.4

--- a/R-package/README.md
+++ b/R-package/README.md
@@ -6,7 +6,7 @@
 ## RGF (Regularized Greedy Forest)
 <br>
 
-**UPDATE 17-08-2018**: Now RGF is part of the [official RGF repository](https://github.com/RGF-team/rgf/tree/master/R-package) and active development is performed there. This repository is archived.
+**UPDATE 17-08-2018**: Now RGF is part of the [official RGF repository](https://github.com/RGF-team/rgf/tree/master/R-package) and active development is performed there. **The *mlampros/RGF* repository is archived.**
 
 <br>
 

--- a/R-package/README.md
+++ b/R-package/README.md
@@ -6,6 +6,9 @@
 ## RGF (Regularized Greedy Forest)
 <br>
 
+**UPDATE 17-08-2018**: Now RGF is part of the [official RGF repository](https://github.com/RGF-team/rgf/tree/master/R-package) and active development is performed there. This repository is archived.
+
+<br>
 
 The **RGF** package is a wrapper of the [Regularized Greedy Forest (RGF)](https://github.com/RGF-team/rgf_python) *python* package, which also includes a [Multi-core implementation (FastRGF)](https://github.com/RGF-team/rgf/tree/master/FastRGF). More details on the functionality of the RGF package can be found in the [blog-post](http://mlampros.github.io/2018/02/14/the_RGF_package/) and in the package Documentation. 
 

--- a/R-package/man/FastRGF_Classifier.Rd
+++ b/R-package/man/FastRGF_Classifier.Rd
@@ -112,7 +112,7 @@ the \emph{score} function returns the mean accuracy on the given test data and l
  \item{\code{--------------}}{}
 
  \item{\code{score(x, y, sample_weight = NULL)}}{}
- 
+
  \item{\code{--------------}}{}
  }
 }

--- a/R-package/man/FastRGF_Regressor.Rd
+++ b/R-package/man/FastRGF_Regressor.Rd
@@ -100,7 +100,7 @@ the \emph{score} function returns the coefficient of determination ( R^2 ) for t
  \item{\code{--------------}}{}
 
  \item{\code{score(x, y, sample_weight = NULL)}}{}
- 
+
  \item{\code{--------------}}{}
  }
 }

--- a/R-package/man/RGF_Classifier.Rd
+++ b/R-package/man/RGF_Classifier.Rd
@@ -112,13 +112,13 @@ the \emph{dump_model} function currently prints information about the fitted mod
  \item{\code{--------------}}{}
 
  \item{\code{score(x, y, sample_weight = NULL)}}{}
- 
+
  \item{\code{--------------}}{}
- 
+
  \item{\code{feature_importances()}}{}
 
  \item{\code{--------------}}{}
- 
+
  \item{\code{dump_model()}}{}
 
  \item{\code{--------------}}{}

--- a/R-package/man/RGF_Regressor.Rd
+++ b/R-package/man/RGF_Regressor.Rd
@@ -100,13 +100,13 @@ the \emph{dump_model} function currently prints information about the fitted mod
  \item{\code{--------------}}{}
 
  \item{\code{score(x, y, sample_weight = NULL)}}{}
- 
+
  \item{\code{--------------}}{}
- 
+
  \item{\code{feature_importances()}}{}
 
  \item{\code{--------------}}{}
- 
+
  \item{\code{dump_model()}}{}
 
  \item{\code{--------------}}{}

--- a/R-package/man/TO_scipy_sparse.Rd
+++ b/R-package/man/TO_scipy_sparse.Rd
@@ -20,39 +20,41 @@ The \emph{dgCMatrix} class is a class of sparse numeric matrices in the compress
 \examples{
 
 if (reticulate::py_available() && reticulate::py_module_available("scipy")) {
-  
+
   if (Sys.info()["sysname"] != 'Darwin') {
 
     library(RGF)
-  
-  
+
+
     # 'dgCMatrix' sparse matrix
     #--------------------------
-  
+
     data = c(1, 0, 2, 0, 0, 3, 4, 5, 6)
-  
-    dgcM = Matrix::Matrix(data = data, nrow = 3,
-  
-                          ncol = 3, byrow = TRUE,
-  
-                          sparse = TRUE)
-  
+
+    dgcM = Matrix::Matrix(
+        data = data
+        , nrow = 3
+        , ncol = 3
+        , byrow = TRUE
+        , sparse = TRUE
+    )
+
     print(dim(dgcM))
-  
+
     res = TO_scipy_sparse(dgcM)
-  
+
     print(res$shape)
-    
-    
+
+
     # 'dgRMatrix' sparse matrix
     #--------------------------
-    
+
     dgrM = as(dgcM, "RsparseMatrix")
-    
+
     print(dim(dgrM))
-  
+
     res_dgr = TO_scipy_sparse(dgrM)
-  
+
     print(res_dgr$shape)
   }
 }


### PR DESCRIPTION
I just updated the RGF R package to CRAN version 1.0.5 using the updates from this repository. I also archived the RGF repository in my Github account. 

From now on please let me know (notify me) when I have to submit the new version to CRAN. The CRAN policy allows R package maintainers to submit a new version of an R package once per month.