### PR TITLE
fix sklearn compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -60,7 +60,7 @@ install:
   - pip install dist/rgf_python-$RGF_VER.tar.gz -v
 
 script:
-  - pytest tests/ -v
+  - pytest tests/ -v || travis_terminate -1
   - if [[ $TASK == "R_PACKAGE" ]]; then
       bash $TRAVIS_BUILD_DIR/R-package/.R.travis.sh;
     fi

--- a/python-package/rgf/fastrgf_model.py
+++ b/python-package/rgf/fastrgf_model.py
@@ -277,7 +277,7 @@ class FastRGFEstimatorBase(utils.CommonRGFEstimatorBase):
         The concrete maximum number of discretized values (bins)
         used in model building process for given data.
         """
-        if self._max_bin is None:
+        if not hasattr(self, '_max_bin'):
             raise NotFittedError(utils.NOT_FITTED_ERROR_DESC)
         else:
             return self._max_bin
@@ -288,7 +288,7 @@ class FastRGFEstimatorBase(utils.CommonRGFEstimatorBase):
         Minimum number of training data points in each leaf node
         used in model building process.
         """
-        if self._min_samples_leaf is None:
+        if not hasattr(self, '_min_samples_leaf'):
             raise NotFittedError(utils.NOT_FITTED_ERROR_DESC)
         else:
             return self._min_samples_leaf
@@ -317,12 +317,14 @@ class FastRGFEstimatorBase(utils.CommonRGFEstimatorBase):
         else:
             self._n_jobs = self.n_jobs
 
+        self._set_target_and_loss()
+
     def _get_params(self):
         return dict(max_depth=self.max_depth,
                     max_leaf=self.max_leaf,
                     tree_gain_ratio=self.tree_gain_ratio,
                     min_samples_leaf=self._min_samples_leaf,
-                    loss=self.loss,
+                    loss=self._loss,
                     l1=self.l1,
                     l2=self.l2,
                     opt_algorithm=self.opt_algorithm,
@@ -378,26 +380,21 @@ class FastRGFRegressor(FastRGFEstimatorBase, RegressorMixin,
         self.max_leaf = max_leaf
         self.tree_gain_ratio = tree_gain_ratio
         self.min_samples_leaf = min_samples_leaf
-        self._min_samples_leaf = None
-        self.loss = "LS"  # Regressor can use only LS loss.
         self.l1 = l1
         self.l2 = l2
         self.opt_algorithm = opt_algorithm
         self.learning_rate = learning_rate
         self.max_bin = max_bin
-        self._max_bin = None
         self.min_child_weight = min_child_weight
         self.data_l2 = data_l2
         self.sparse_max_features = sparse_max_features
         self.sparse_min_occurences = sparse_min_occurences
         self.n_jobs = n_jobs
-        self._n_jobs = None
         self.verbose = verbose
 
-        self._estimators = None
-        self._n_features = None
-        self._fitted = None
+    def _set_target_and_loss(self):
         self._target = "REAL"
+        self._loss = "LS"  # Regressor can use only LS loss.
 
     _regressor_specific_values = {
         '{%estimator_type%}': 'regressor',
@@ -440,30 +437,23 @@ class FastRGFClassifier(FastRGFEstimatorBase, ClassifierMixin,
         self.max_leaf = max_leaf
         self.tree_gain_ratio = tree_gain_ratio
         self.min_samples_leaf = min_samples_leaf
-        self._min_samples_leaf = None
         self.loss = loss
         self.l1 = l1
         self.l2 = l2
         self.opt_algorithm = opt_algorithm
         self.learning_rate = learning_rate
         self.max_bin = max_bin
-        self._max_bin = None
         self.min_child_weight = min_child_weight
         self.data_l2 = data_l2
         self.sparse_max_features = sparse_max_features
         self.sparse_min_occurences = sparse_min_occurences
         self.calc_prob = calc_prob
         self.n_jobs = n_jobs
-        self._n_jobs = None
         self.verbose = verbose
 
-        self._estimators = None
-        self._classes = None
-        self._classes_map = {}
-        self._n_classes = None
-        self._n_features = None
-        self._fitted = None
+    def _set_target_and_loss(self):
         self._target = "BINARY"
+        self._loss = self.loss
 
     _classifier_specific_values = {
         '{%estimator_type%}': 'classifier',

--- a/python-package/rgf/rgf_model.py
+++ b/python-package/rgf/rgf_model.py
@@ -280,7 +280,7 @@ class RGFEstimatorBase(utils.CommonRGFEstimatorBase):
         The concrete regularization value for the process of growing the forest
         used in model building process.
         """
-        if self._sl2 is None:
+        if not hasattr(self, '_sl2'):
             raise NotFittedError(utils.NOT_FITTED_ERROR_DESC)
         else:
             return self._sl2
@@ -291,7 +291,7 @@ class RGFEstimatorBase(utils.CommonRGFEstimatorBase):
         Minimum number of training data points in each leaf node
         used in model building process.
         """
-        if self._min_samples_leaf is None:
+        if not hasattr(self, '_min_samples_leaf'):
             raise NotFittedError(utils.NOT_FITTED_ERROR_DESC)
         else:
             return self._min_samples_leaf
@@ -302,7 +302,7 @@ class RGFEstimatorBase(utils.CommonRGFEstimatorBase):
         Number of iterations of coordinate descent to optimize weights
         used in model building process depending on the specified loss function.
         """
-        if self._n_iter is None:
+        if not hasattr(self, '_n_iter'):
             raise NotFittedError(utils.NOT_FITTED_ERROR_DESC)
         else:
             return self._n_iter
@@ -398,7 +398,7 @@ class RGFEstimatorBase(utils.CommonRGFEstimatorBase):
         The feature importances.
         The importance of a feature is computed from sum of gain of each node.
         """
-        if self._fitted is None:
+        if not hasattr(self, '_fitted') or not self._fitted:
             raise NotFittedError(utils.NOT_FITTED_ERROR_DESC)
         return np.mean([est.feature_importances_ for est in self._estimators], axis=0)
 
@@ -429,21 +429,14 @@ class RGFRegressor(RGFEstimatorBase, RegressorMixin, utils.RGFRegressorMixin):
         self.reg_depth = reg_depth
         self.l2 = l2
         self.sl2 = sl2
-        self._sl2 = None
         self.normalize = normalize
         self.min_samples_leaf = min_samples_leaf
-        self._min_samples_leaf = None
         self.n_iter = n_iter
-        self._n_iter = None
         self.n_tree_search = n_tree_search
         self.opt_interval = opt_interval
         self.learning_rate = learning_rate
         self.memory_policy = memory_policy
         self.verbose = verbose
-
-        self._n_features = None
-        self._estimators = None
-        self._fitted = None
 
     _regressor_specific_values = {
         '{%estimator_type%}': 'regressor',
@@ -489,12 +482,9 @@ class RGFClassifier(RGFEstimatorBase, ClassifierMixin, utils.RGFClassifierMixin)
         self.reg_depth = reg_depth
         self.l2 = l2
         self.sl2 = sl2
-        self._sl2 = None
         self.normalize = normalize
         self.min_samples_leaf = min_samples_leaf
-        self._min_samples_leaf = None
         self.n_iter = n_iter
-        self._n_iter = None
         self.n_tree_search = n_tree_search
         self.opt_interval = opt_interval
         self.learning_rate = learning_rate
@@ -502,13 +492,6 @@ class RGFClassifier(RGFEstimatorBase, ClassifierMixin, utils.RGFClassifierMixin)
         self.n_jobs = n_jobs
         self.memory_policy = memory_policy
         self.verbose = verbose
-
-        self._estimators = None
-        self._classes = None
-        self._classes_map = {}
-        self._n_classes = None
-        self._n_features = None
-        self._fitted = None
 
     _classifier_specific_values = {
         '{%estimator_type%}': 'classifier',

--- a/python-package/rgf/utils.py
+++ b/python-package/rgf/utils.py
@@ -249,7 +249,7 @@ class CommonRGFExecuterBase(BaseEstimator):
 
         self._file_prefix = str(uuid4()) + str(COUNTER.increment())
         UUIDS.append(self._file_prefix)
-        self._fitted = None
+        self._fitted = False
 
     def _set_paths(self):
         self._train_x_loc = os.path.join(TEMP_PATH, self._file_prefix + ".train.data.x")
@@ -320,7 +320,7 @@ class CommonRGFExecuterBase(BaseEstimator):
         return np.loadtxt(self._pred_loc)
 
     def _check_fitted(self):
-        if self._fitted is None:
+        if not self._fitted:
             raise NotFittedError(NOT_FITTED_ERROR_DESC)
         if not os.path.isfile(self._model_file):
             raise Exception('Model learning result is not found in {0}. '
@@ -360,7 +360,7 @@ class CommonRGFEstimatorBase(BaseEstimator):
     @property
     def n_features_(self):
         """The number of features when `fit` is performed."""
-        if self._n_features is None:
+        if not hasattr(self, '_n_features'):
             raise NotFittedError(NOT_FITTED_ERROR_DESC)
         else:
             return self._n_features
@@ -368,10 +368,10 @@ class CommonRGFEstimatorBase(BaseEstimator):
     @property
     def fitted_(self):
         """Indicates whether `fit` is performed."""
-        if self._fitted is None:
+        if not hasattr(self, '_fitted') or not self._fitted:
             raise NotFittedError(NOT_FITTED_ERROR_DESC)
         else:
-            return self._fitted
+            return True
 
     def _get_sample_weight(self, sample_weight):
         if sample_weight is not None:
@@ -396,7 +396,7 @@ class CommonRGFEstimatorBase(BaseEstimator):
     @property
     def estimators_(self):
         """The collection of fitted sub-estimators when `fit` is performed."""
-        if self._estimators is None:
+        if not hasattr(self, '_estimators'):
             raise NotFittedError(NOT_FITTED_ERROR_DESC)
         else:
             return self._estimators
@@ -412,13 +412,13 @@ class CommonRGFEstimatorBase(BaseEstimator):
             Returns the number of removed files.
         """
         n_removed_files = 0
-        if self._estimators is not None:
+        if hasattr(self, '_estimators'):
             for est in self._estimators:
                 n_removed_files += cleanup_partial(est._file_prefix,
                                                    remove_from_list=True)
 
         # No more able to predict without refitting.
-        self._fitted = None
+        self._fitted = False
         return n_removed_files
 
     def _get_params(self):
@@ -438,7 +438,7 @@ class RGFClassifierMixin(object):
     @property
     def classes_(self):
         """The classes labels when `fit` is performed."""
-        if self._classes is None:
+        if not hasattr(self, '_classes'):
             raise NotFittedError(NOT_FITTED_ERROR_DESC)
         else:
             return self._classes
@@ -446,7 +446,7 @@ class RGFClassifierMixin(object):
     @property
     def n_classes_(self):
         """The number of classes when `fit` is performed."""
-        if self._n_classes is None:
+        if not hasattr(self, '_n_classes'):
             raise NotFittedError(NOT_FITTED_ERROR_DESC)
         else:
             return self._n_classes
@@ -484,6 +484,7 @@ class RGFClassifierMixin(object):
         check_classification_targets(y)
         self._classes = sorted(np.unique(y))
         self._n_classes = len(self._classes)
+        self._classes_map = {}
 
         self._set_params_with_dependencies()
         params = self._get_params()
@@ -543,7 +544,7 @@ class RGFClassifierMixin(object):
             The class probabilities of the input samples.
             The order of the classes corresponds to that in the attribute classes_.
         """
-        if self._fitted is None:
+        if not hasattr(self, '_fitted') or not self._fitted:
             raise NotFittedError(NOT_FITTED_ERROR_DESC)
         X = check_array(X, accept_sparse=True)
         self._check_n_features(X.shape[1])
@@ -625,7 +626,7 @@ class RGFRegressorMixin(object):
         y : array of shape = [n_samples]
             The predicted values.
         """
-        if self._fitted is None:
+        if not hasattr(self, '_fitted') or not self._fitted:
             raise NotFittedError(NOT_FITTED_ERROR_DESC)
         X = check_array(X, accept_sparse=True)
         self._check_n_features(X.shape[1])

--- a/python-package/tests/test_rgf_python.py
+++ b/python-package/tests/test_rgf_python.py
@@ -281,7 +281,7 @@ class TestRGFClassfier(RGFClassfierBaseTest, unittest.TestCase):
 
         fi = clf.feature_importances_
         self.assertEqual(fi.shape[0], self.X_train.shape[1])
-        self.assertAlmostEquals(fi.sum(), 1)
+        self.assertAlmostEqual(fi.sum(), 1)
 
 
 class TestFastRGFClassfier(RGFClassfierBaseTest, unittest.TestCase):
@@ -573,7 +573,7 @@ class TestRGFRegressor(RGFRegressorBaseTest, unittest.TestCase):
 
         fi = reg.feature_importances_
         self.assertEqual(fi.shape[0], self.X_train.shape[1])
-        self.assertAlmostEquals(fi.sum(), 1)
+        self.assertAlmostEqual(fi.sum(), 1)
 
 
 class TestFastRGFRegressor(RGFRegressorBaseTest, unittest.TestCase):


### PR DESCRIPTION
In new scikit-learn version (0.20.0) it is not allowed to create even private attributes in `__init__` method.

See this check:
https://github.com/scikit-learn/scikit-learn/blob/d88bef17eaa9d81e152c8b914fad7cf45f5e8393/sklearn/utils/estimator_checks.py#L1965-L1995