### PR TITLE
fix new sklearn and joblib compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -60,7 +60,7 @@ install:
   - pip install dist/rgf_python-$RGF_VER.tar.gz -v
 
 script:
-  - pytest tests/ -v
+  - pytest tests/ -v || travis_terminate -1
   - if [[ $TASK == "R_PACKAGE" ]]; then
       bash $TRAVIS_BUILD_DIR/R-package/.R.travis.sh;
     fi

--- a/python-package/rgf/fastrgf_model.py
+++ b/python-package/rgf/fastrgf_model.py
@@ -320,25 +320,27 @@ class FastRGFEstimatorBase(utils.CommonRGFEstimatorBase):
         self._set_target_and_loss()
 
     def _get_params(self):
-        return dict(max_depth=self.max_depth,
-                    max_leaf=self.max_leaf,
-                    tree_gain_ratio=self.tree_gain_ratio,
-                    min_samples_leaf=self._min_samples_leaf,
-                    loss=self._loss,
-                    l1=self.l1,
-                    l2=self.l2,
-                    opt_algorithm=self.opt_algorithm,
-                    n_estimators=self.n_estimators,
-                    learning_rate=self.learning_rate,
-                    max_bin=self._max_bin,
-                    data_l2=self.data_l2,
-                    min_child_weight=self.min_child_weight,
-                    sparse_max_features=self.sparse_max_features,
-                    sparse_min_occurences=self.sparse_min_occurences,
-                    n_jobs=self._n_jobs,
-                    verbose=self.verbose,
-                    is_classification=is_classifier(self),
-                    target=self._target)
+        res = super(FastRGFEstimatorBase, self)._get_params()
+        res.update(dict(max_depth=self.max_depth,
+                        max_leaf=self.max_leaf,
+                        tree_gain_ratio=self.tree_gain_ratio,
+                        min_samples_leaf=self._min_samples_leaf,
+                        loss=self._loss,
+                        l1=self.l1,
+                        l2=self.l2,
+                        opt_algorithm=self.opt_algorithm,
+                        n_estimators=self.n_estimators,
+                        learning_rate=self.learning_rate,
+                        max_bin=self._max_bin,
+                        data_l2=self.data_l2,
+                        min_child_weight=self.min_child_weight,
+                        sparse_max_features=self.sparse_max_features,
+                        sparse_min_occurences=self.sparse_min_occurences,
+                        n_jobs=self._n_jobs,
+                        verbose=self.verbose,
+                        is_classification=is_classifier(self),
+                        target=self._target))
+        return res
 
     def _fit_binary_task(self, X, y, sample_weight, params):
         self._estimators[0] = FastRGFExecuter(**params).fit(X, y, sample_weight)
@@ -373,8 +375,9 @@ class FastRGFRegressor(FastRGFEstimatorBase, RegressorMixin,
                  sparse_min_occurences=5,
                  n_jobs=-1,
                  verbose=0):
-        if not utils.CONFIG.FASTRGF_AVAILABLE:
+        if not utils.Config().FASTRGF_AVAILABLE:
             raise Exception('FastRGF estimators are unavailable for usage.')
+        super(FastRGFRegressor, self).__init__()
         self.n_estimators = n_estimators
         self.max_depth = max_depth
         self.max_leaf = max_leaf
@@ -430,8 +433,9 @@ class FastRGFClassifier(FastRGFEstimatorBase, ClassifierMixin,
                  calc_prob="sigmoid",
                  n_jobs=-1,
                  verbose=0):
-        if not utils.CONFIG.FASTRGF_AVAILABLE:
+        if not utils.Config().FASTRGF_AVAILABLE:
             raise Exception('FastRGF estimators are unavailable for usage.')
+        super(FastRGFClassifier, self).__init__()
         self.n_estimators = n_estimators
         self.max_depth = max_depth
         self.max_leaf = max_leaf
@@ -533,7 +537,7 @@ class FastRGFExecuter(utils.CommonRGFExecuterBase):
         params.append("set.verbose=%s" % self.verbose)
         params.append("model.save=%s" % self._model_file_loc)
 
-        cmd = [os.path.join(utils.CONFIG.FASTRGF_PATH, "forest_train")]
+        cmd = [os.path.join(self.config.FASTRGF_PATH, "forest_train")]
         cmd.extend(params)
 
         return cmd
@@ -541,7 +545,7 @@ class FastRGFExecuter(utils.CommonRGFExecuterBase):
     def _find_model_file(self):
         if not os.path.isfile(self._model_file_loc):
             raise Exception('Model learning result is not found in {0}. '
-                            'Training is abnormally finished.'.format(utils.CONFIG.TEMP_PATH))
+                            'Training is abnormally finished.'.format(self.config.TEMP_PATH))
         self._model_file = self._model_file_loc
 
     def _get_test_command(self, is_sparse_test_X):
@@ -555,7 +559,7 @@ class FastRGFExecuter(utils.CommonRGFExecuterBase):
         params.append("set.nthreads=%s" % self.n_jobs)
         params.append("set.verbose=%s" % self.verbose)
 
-        cmd = [os.path.join(utils.CONFIG.FASTRGF_PATH, "forest_predict")]
+        cmd = [os.path.join(self.config.FASTRGF_PATH, "forest_predict")]
         cmd.extend(params)
 
         return cmd

--- a/python-package/rgf/fastrgf_model.py
+++ b/python-package/rgf/fastrgf_model.py
@@ -373,7 +373,7 @@ class FastRGFRegressor(FastRGFEstimatorBase, RegressorMixin,
                  sparse_min_occurences=5,
                  n_jobs=-1,
                  verbose=0):
-        if not utils.FASTRGF_AVAILABLE:
+        if not utils.CONFIG.FASTRGF_AVAILABLE:
             raise Exception('FastRGF estimators are unavailable for usage.')
         self.n_estimators = n_estimators
         self.max_depth = max_depth
@@ -430,7 +430,7 @@ class FastRGFClassifier(FastRGFEstimatorBase, ClassifierMixin,
                  calc_prob="sigmoid",
                  n_jobs=-1,
                  verbose=0):
-        if not utils.FASTRGF_AVAILABLE:
+        if not utils.CONFIG.FASTRGF_AVAILABLE:
             raise Exception('FastRGF estimators are unavailable for usage.')
         self.n_estimators = n_estimators
         self.max_depth = max_depth
@@ -533,7 +533,7 @@ class FastRGFExecuter(utils.CommonRGFExecuterBase):
         params.append("set.verbose=%s" % self.verbose)
         params.append("model.save=%s" % self._model_file_loc)
 
-        cmd = [os.path.join(utils.FASTRGF_PATH, "forest_train")]
+        cmd = [os.path.join(utils.CONFIG.FASTRGF_PATH, "forest_train")]
         cmd.extend(params)
 
         return cmd
@@ -541,7 +541,7 @@ class FastRGFExecuter(utils.CommonRGFExecuterBase):
     def _find_model_file(self):
         if not os.path.isfile(self._model_file_loc):
             raise Exception('Model learning result is not found in {0}. '
-                            'Training is abnormally finished.'.format(utils.TEMP_PATH))
+                            'Training is abnormally finished.'.format(utils.CONFIG.TEMP_PATH))
         self._model_file = self._model_file_loc
 
     def _get_test_command(self, is_sparse_test_X):
@@ -555,7 +555,7 @@ class FastRGFExecuter(utils.CommonRGFExecuterBase):
         params.append("set.nthreads=%s" % self.n_jobs)
         params.append("set.verbose=%s" % self.verbose)
 
-        cmd = [os.path.join(utils.FASTRGF_PATH, "forest_predict")]
+        cmd = [os.path.join(utils.CONFIG.FASTRGF_PATH, "forest_predict")]
         cmd.extend(params)
 
         return cmd

--- a/python-package/rgf/fastrgf_model.py
+++ b/python-package/rgf/fastrgf_model.py
@@ -277,7 +277,7 @@ class FastRGFEstimatorBase(utils.CommonRGFEstimatorBase):
         The concrete maximum number of discretized values (bins)
         used in model building process for given data.
         """
-        if self._max_bin is None:
+        if not hasattr(self, '_max_bin'):
             raise NotFittedError(utils.NOT_FITTED_ERROR_DESC)
         else:
             return self._max_bin
@@ -288,7 +288,7 @@ class FastRGFEstimatorBase(utils.CommonRGFEstimatorBase):
         Minimum number of training data points in each leaf node
         used in model building process.
         """
-        if self._min_samples_leaf is None:
+        if not hasattr(self, '_min_samples_leaf'):
             raise NotFittedError(utils.NOT_FITTED_ERROR_DESC)
         else:
             return self._min_samples_leaf
@@ -317,12 +317,14 @@ class FastRGFEstimatorBase(utils.CommonRGFEstimatorBase):
         else:
             self._n_jobs = self.n_jobs
 
+        self._set_target_and_loss()
+
     def _get_params(self):
         return dict(max_depth=self.max_depth,
                     max_leaf=self.max_leaf,
                     tree_gain_ratio=self.tree_gain_ratio,
                     min_samples_leaf=self._min_samples_leaf,
-                    loss=self.loss,
+                    loss=self._loss,
                     l1=self.l1,
                     l2=self.l2,
                     opt_algorithm=self.opt_algorithm,
@@ -378,26 +380,21 @@ class FastRGFRegressor(FastRGFEstimatorBase, RegressorMixin,
         self.max_leaf = max_leaf
         self.tree_gain_ratio = tree_gain_ratio
         self.min_samples_leaf = min_samples_leaf
-        self._min_samples_leaf = None
-        self.loss = "LS"  # Regressor can use only LS loss.
         self.l1 = l1
         self.l2 = l2
         self.opt_algorithm = opt_algorithm
         self.learning_rate = learning_rate
         self.max_bin = max_bin
-        self._max_bin = None
         self.min_child_weight = min_child_weight
         self.data_l2 = data_l2
         self.sparse_max_features = sparse_max_features
         self.sparse_min_occurences = sparse_min_occurences
         self.n_jobs = n_jobs
-        self._n_jobs = None
         self.verbose = verbose
 
-        self._estimators = None
-        self._n_features = None
-        self._fitted = None
+    def _set_target_and_loss(self):
         self._target = "REAL"
+        self._loss = "LS"  # Regressor can use only LS loss.
 
     _regressor_specific_values = {
         '{%estimator_type%}': 'regressor',
@@ -440,30 +437,23 @@ class FastRGFClassifier(FastRGFEstimatorBase, ClassifierMixin,
         self.max_leaf = max_leaf
         self.tree_gain_ratio = tree_gain_ratio
         self.min_samples_leaf = min_samples_leaf
-        self._min_samples_leaf = None
         self.loss = loss
         self.l1 = l1
         self.l2 = l2
         self.opt_algorithm = opt_algorithm
         self.learning_rate = learning_rate
         self.max_bin = max_bin
-        self._max_bin = None
         self.min_child_weight = min_child_weight
         self.data_l2 = data_l2
         self.sparse_max_features = sparse_max_features
         self.sparse_min_occurences = sparse_min_occurences
         self.calc_prob = calc_prob
         self.n_jobs = n_jobs
-        self._n_jobs = None
         self.verbose = verbose
 
-        self._estimators = None
-        self._classes = None
-        self._classes_map = {}
-        self._n_classes = None
-        self._n_features = None
-        self._fitted = None
+    def _set_target_and_loss(self):
         self._target = "BINARY"
+        self._loss = self.loss
 
     _classifier_specific_values = {
         '{%estimator_type%}': 'classifier',

--- a/python-package/rgf/rgf_model.py
+++ b/python-package/rgf/rgf_model.py
@@ -280,7 +280,7 @@ class RGFEstimatorBase(utils.CommonRGFEstimatorBase):
         The concrete regularization value for the process of growing the forest
         used in model building process.
         """
-        if self._sl2 is None:
+        if not hasattr(self, '_sl2'):
             raise NotFittedError(utils.NOT_FITTED_ERROR_DESC)
         else:
             return self._sl2
@@ -291,7 +291,7 @@ class RGFEstimatorBase(utils.CommonRGFEstimatorBase):
         Minimum number of training data points in each leaf node
         used in model building process.
         """
-        if self._min_samples_leaf is None:
+        if not hasattr(self, '_min_samples_leaf'):
             raise NotFittedError(utils.NOT_FITTED_ERROR_DESC)
         else:
             return self._min_samples_leaf
@@ -302,7 +302,7 @@ class RGFEstimatorBase(utils.CommonRGFEstimatorBase):
         Number of iterations of coordinate descent to optimize weights
         used in model building process depending on the specified loss function.
         """
-        if self._n_iter is None:
+        if not hasattr(self, '_n_iter'):
             raise NotFittedError(utils.NOT_FITTED_ERROR_DESC)
         else:
             return self._n_iter
@@ -398,7 +398,7 @@ class RGFEstimatorBase(utils.CommonRGFEstimatorBase):
         The feature importances.
         The importance of a feature is computed from sum of gain of each node.
         """
-        if self._fitted is None:
+        if not hasattr(self, '_fitted') or not self._fitted:
             raise NotFittedError(utils.NOT_FITTED_ERROR_DESC)
         return np.mean([est.feature_importances_ for est in self._estimators], axis=0)
 
@@ -429,21 +429,14 @@ class RGFRegressor(RGFEstimatorBase, RegressorMixin, utils.RGFRegressorMixin):
         self.reg_depth = reg_depth
         self.l2 = l2
         self.sl2 = sl2
-        self._sl2 = None
         self.normalize = normalize
         self.min_samples_leaf = min_samples_leaf
-        self._min_samples_leaf = None
         self.n_iter = n_iter
-        self._n_iter = None
         self.n_tree_search = n_tree_search
         self.opt_interval = opt_interval
         self.learning_rate = learning_rate
         self.memory_policy = memory_policy
         self.verbose = verbose
-
-        self._n_features = None
-        self._estimators = None
-        self._fitted = None
 
     _regressor_specific_values = {
         '{%estimator_type%}': 'regressor',
@@ -489,12 +482,9 @@ class RGFClassifier(RGFEstimatorBase, ClassifierMixin, utils.RGFClassifierMixin)
         self.reg_depth = reg_depth
         self.l2 = l2
         self.sl2 = sl2
-        self._sl2 = None
         self.normalize = normalize
         self.min_samples_leaf = min_samples_leaf
-        self._min_samples_leaf = None
         self.n_iter = n_iter
-        self._n_iter = None
         self.n_tree_search = n_tree_search
         self.opt_interval = opt_interval
         self.learning_rate = learning_rate
@@ -502,13 +492,6 @@ class RGFClassifier(RGFEstimatorBase, ClassifierMixin, utils.RGFClassifierMixin)
         self.n_jobs = n_jobs
         self.memory_policy = memory_policy
         self.verbose = verbose
-
-        self._estimators = None
-        self._classes = None
-        self._classes_map = {}
-        self._n_classes = None
-        self._n_features = None
-        self._fitted = None
 
     _classifier_specific_values = {
         '{%estimator_type%}': 'classifier',

--- a/python-package/rgf/rgf_model.py
+++ b/python-package/rgf/rgf_model.py
@@ -420,7 +420,7 @@ class RGFRegressor(RGFEstimatorBase, RegressorMixin, utils.RGFRegressorMixin):
                  learning_rate=0.5,
                  memory_policy="generous",
                  verbose=0):
-        if not utils.RGF_AVAILABLE:
+        if not utils.CONFIG.RGF_AVAILABLE:
             raise Exception('RGF estimators are unavailable for usage.')
         self.max_leaf = max_leaf
         self.test_interval = test_interval
@@ -473,7 +473,7 @@ class RGFClassifier(RGFEstimatorBase, ClassifierMixin, utils.RGFClassifierMixin)
                  n_jobs=-1,
                  memory_policy="generous",
                  verbose=0):
-        if not utils.RGF_AVAILABLE:
+        if not utils.CONFIG.RGF_AVAILABLE:
             raise Exception('RGF estimators are unavailable for usage.')
         self.max_leaf = max_leaf
         self.test_interval = test_interval
@@ -565,7 +565,7 @@ class RGFExecuter(utils.CommonRGFExecuterBase):
         if self._use_sample_weight:
             params.append("train_w_fn=%s" % self._train_weight_loc)
 
-        cmd = (utils.RGF_PATH, "train", ",".join(params))
+        cmd = (utils.CONFIG.RGF_PATH, "train", ",".join(params))
 
         return cmd
 
@@ -573,7 +573,7 @@ class RGFExecuter(utils.CommonRGFExecuterBase):
         model_files = glob(self._model_file_loc + "*")
         if not model_files:
             raise Exception('Model learning result is not found in {0}. '
-                            'Training is abnormally finished.'.format(utils.TEMP_PATH))
+                            'Training is abnormally finished.'.format(utils.CONFIG.TEMP_PATH))
         self._model_file = sorted(model_files, reverse=True)[0]
 
     def _get_test_command(self, is_sparse_test_X):
@@ -582,13 +582,13 @@ class RGFExecuter(utils.CommonRGFExecuterBase):
         params.append("prediction_fn=%s" % self._pred_loc)
         params.append("model_fn=%s" % self._model_file)
 
-        cmd = (utils.RGF_PATH, "predict", ",".join(params))
+        cmd = (utils.CONFIG.RGF_PATH, "predict", ",".join(params))
 
         return cmd
 
     def dump_model(self):
         self._check_fitted()
-        cmd = (utils.RGF_PATH, "dump_model", "model_fn=%s" % self._model_file)
+        cmd = (utils.CONFIG.RGF_PATH, "dump_model", "model_fn=%s" % self._model_file)
         self._execute_command(cmd, force_verbose=True)
 
     @property
@@ -597,6 +597,6 @@ class RGFExecuter(utils.CommonRGFExecuterBase):
         params.append("train_x_fn=%s" % self._train_x_loc)
         params.append("feature_importances_fn=%s" % self._feature_importances_loc)
         params.append("model_fn=%s" % self._model_file)
-        cmd = (utils.RGF_PATH, "feature_importances", ",".join(params))
+        cmd = (utils.CONFIG.RGF_PATH, "feature_importances", ",".join(params))
         self._execute_command(cmd)
         return np.loadtxt(self._feature_importances_loc)

--- a/python-package/rgf/utils.py
+++ b/python-package/rgf/utils.py
@@ -249,7 +249,7 @@ class CommonRGFExecuterBase(BaseEstimator):
 
         self._file_prefix = str(uuid4()) + str(COUNTER.increment())
         UUIDS.append(self._file_prefix)
-        self._fitted = None
+        self._fitted = False
 
     def _set_paths(self):
         self._train_x_loc = os.path.join(TEMP_PATH, self._file_prefix + ".train.data.x")
@@ -320,7 +320,7 @@ class CommonRGFExecuterBase(BaseEstimator):
         return np.loadtxt(self._pred_loc)
 
     def _check_fitted(self):
-        if self._fitted is None:
+        if not self._fitted:
             raise NotFittedError(NOT_FITTED_ERROR_DESC)
         if not os.path.isfile(self._model_file):
             raise Exception('Model learning result is not found in {0}. '
@@ -360,7 +360,7 @@ class CommonRGFEstimatorBase(BaseEstimator):
     @property
     def n_features_(self):
         """The number of features when `fit` is performed."""
-        if self._n_features is None:
+        if not hasattr(self, '_n_features'):
             raise NotFittedError(NOT_FITTED_ERROR_DESC)
         else:
             return self._n_features
@@ -368,10 +368,10 @@ class CommonRGFEstimatorBase(BaseEstimator):
     @property
     def fitted_(self):
         """Indicates whether `fit` is performed."""
-        if self._fitted is None:
+        if not hasattr(self, '_fitted') or not self._fitted:
             raise NotFittedError(NOT_FITTED_ERROR_DESC)
         else:
-            return self._fitted
+            return True
 
     def _get_sample_weight(self, sample_weight):
         if sample_weight is not None:
@@ -396,7 +396,7 @@ class CommonRGFEstimatorBase(BaseEstimator):
     @property
     def estimators_(self):
         """The collection of fitted sub-estimators when `fit` is performed."""
-        if self._estimators is None:
+        if not hasattr(self, '_estimators'):
             raise NotFittedError(NOT_FITTED_ERROR_DESC)
         else:
             return self._estimators
@@ -412,13 +412,13 @@ class CommonRGFEstimatorBase(BaseEstimator):
             Returns the number of removed files.
         """
         n_removed_files = 0
-        if self._estimators is not None:
+        if hasattr(self, '_estimators'):
             for est in self._estimators:
                 n_removed_files += cleanup_partial(est._file_prefix,
                                                    remove_from_list=True)
 
         # No more able to predict without refitting.
-        self._fitted = None
+        self._fitted = False
         return n_removed_files
 
     def _get_params(self):
@@ -438,7 +438,7 @@ class RGFClassifierMixin(object):
     @property
     def classes_(self):
         """The classes labels when `fit` is performed."""
-        if self._classes is None:
+        if not hasattr(self, '_classes'):
             raise NotFittedError(NOT_FITTED_ERROR_DESC)
         else:
             return self._classes
@@ -446,7 +446,7 @@ class RGFClassifierMixin(object):
     @property
     def n_classes_(self):
         """The number of classes when `fit` is performed."""
-        if self._n_classes is None:
+        if not hasattr(self, '_n_classes'):
             raise NotFittedError(NOT_FITTED_ERROR_DESC)
         else:
             return self._n_classes
@@ -484,6 +484,7 @@ class RGFClassifierMixin(object):
         check_classification_targets(y)
         self._classes = sorted(np.unique(y))
         self._n_classes = len(self._classes)
+        self._classes_map = {}
 
         self._set_params_with_dependencies()
         params = self._get_params()
@@ -543,7 +544,7 @@ class RGFClassifierMixin(object):
             The class probabilities of the input samples.
             The order of the classes corresponds to that in the attribute classes_.
         """
-        if self._fitted is None:
+        if not hasattr(self, '_fitted') or not self._fitted:
             raise NotFittedError(NOT_FITTED_ERROR_DESC)
         X = check_array(X, accept_sparse=True)
         self._check_n_features(X.shape[1])
@@ -625,7 +626,7 @@ class RGFRegressorMixin(object):
         y : array of shape = [n_samples]
             The predicted values.
         """
-        if self._fitted is None:
+        if not hasattr(self, '_fitted') or not self._fitted:
             raise NotFittedError(NOT_FITTED_ERROR_DESC)
         X = check_array(X, accept_sparse=True)
         self._check_n_features(X.shape[1])

--- a/python-package/tests/test_rgf_python.py
+++ b/python-package/tests/test_rgf_python.py
@@ -17,7 +17,7 @@ from sklearn.utils.validation import check_random_state
 
 from rgf.sklearn import RGFClassifier, RGFRegressor
 from rgf.sklearn import FastRGFClassifier, FastRGFRegressor
-from rgf.utils import cleanup, TEMP_PATH
+from rgf.utils import cleanup, CONFIG
 
 
 class RGFClassfierBaseTest(object):
@@ -178,7 +178,7 @@ class RGFClassfierBaseTest(object):
         self.assertEqual(clf1.cleanup(), 0)
 
         for est in clf1.estimators_:
-            glob_file = os.path.join(TEMP_PATH, est._file_prefix + "*")
+            glob_file = os.path.join(CONFIG.TEMP_PATH, est._file_prefix + "*")
             self.assertFalse(glob.glob(glob_file))
 
         self.assertRaises(NotFittedError, clf1.predict, self.X_test)
@@ -469,7 +469,7 @@ class RGFRegressorBaseTest(object):
         self.assertNotEqual(reg1.cleanup(), 0)
         self.assertEqual(reg1.cleanup(), 0)
 
-        glob_file = os.path.join(TEMP_PATH, reg1._estimators[0]._file_prefix + "*")
+        glob_file = os.path.join(CONFIG.TEMP_PATH, reg1._estimators[0]._file_prefix + "*")
         self.assertFalse(glob.glob(glob_file))
 
         self.assertRaises(NotFittedError, reg1.predict, self.X_test)

--- a/python-package/tests/test_rgf_python.py
+++ b/python-package/tests/test_rgf_python.py
@@ -281,7 +281,7 @@ class TestRGFClassfier(RGFClassfierBaseTest, unittest.TestCase):
 
         fi = clf.feature_importances_
         self.assertEqual(fi.shape[0], self.X_train.shape[1])
-        self.assertAlmostEquals(fi.sum(), 1)
+        self.assertAlmostEqual(fi.sum(), 1)
 
 
 class TestFastRGFClassfier(RGFClassfierBaseTest, unittest.TestCase):
@@ -573,7 +573,7 @@ class TestRGFRegressor(RGFRegressorBaseTest, unittest.TestCase):
 
         fi = reg.feature_importances_
         self.assertEqual(fi.shape[0], self.X_train.shape[1])
-        self.assertAlmostEquals(fi.sum(), 1)
+        self.assertAlmostEqual(fi.sum(), 1)
 
 
 class TestFastRGFRegressor(RGFRegressorBaseTest, unittest.TestCase):

--- a/python-package/tests/test_rgf_python.py
+++ b/python-package/tests/test_rgf_python.py
@@ -17,7 +17,7 @@ from sklearn.utils.validation import check_random_state
 
 from rgf.sklearn import RGFClassifier, RGFRegressor
 from rgf.sklearn import FastRGFClassifier, FastRGFRegressor
-from rgf.utils import cleanup, CONFIG
+from rgf.utils import cleanup, Config
 
 
 class RGFClassfierBaseTest(object):
@@ -178,7 +178,7 @@ class RGFClassfierBaseTest(object):
         self.assertEqual(clf1.cleanup(), 0)
 
         for est in clf1.estimators_:
-            glob_file = os.path.join(CONFIG.TEMP_PATH, est._file_prefix + "*")
+            glob_file = os.path.join(Config().TEMP_PATH, est._file_prefix + "*")
             self.assertFalse(glob.glob(glob_file))
 
         self.assertRaises(NotFittedError, clf1.predict, self.X_test)
@@ -469,7 +469,7 @@ class RGFRegressorBaseTest(object):
         self.assertNotEqual(reg1.cleanup(), 0)
         self.assertEqual(reg1.cleanup(), 0)
 
-        glob_file = os.path.join(CONFIG.TEMP_PATH, reg1._estimators[0]._file_prefix + "*")
+        glob_file = os.path.join(Config().TEMP_PATH, reg1._estimators[0]._file_prefix + "*")
         self.assertFalse(glob.glob(glob_file))
 
         self.assertRaises(NotFittedError, reg1.predict, self.X_test)


### PR DESCRIPTION
Replaces #251.

In new scikit-learn version (0.20.0) it is not allowed to create even private attributes in `__init__` method.

See this check:
https://github.com/scikit-learn/scikit-learn/blob/d88bef17eaa9d81e152c8b914fad7cf45f5e8393/sklearn/utils/estimator_checks.py#L1965-L1995

New joblib re-imports modules multiple times, which leads to a crash when several workers tries to access the same file, e.g. `temp_rgf.model`, at the same time.
This PR moves all path configuration routines (all routines themselves are left untouched) to a class `Config`, as it was kindly suggested by joblib maintainers (see discussion [here](https://github.com/joblib/joblib/issues/780)), what allows to run `is_rgf_executable()` and `is_fastrgf_executable()` only once.