### PR TITLE
fixed FutureWarning and typos in examples

### DIFF
--- a/python-package/examples/FastRGF/FastRGF_regressor_on_boston_dataset.py
+++ b/python-package/examples/FastRGF/FastRGF_regressor_on_boston_dataset.py
@@ -33,7 +33,7 @@ print("FastRGF: {} sec".format(end - start))
 print("score: {}".format(score))
 
 start = time.time()
-reg = RandomForestRegressor()
+reg = RandomForestRegressor(n_estimators=100)
 reg.fit(train_x, train_y)
 score = reg.score(test_x, test_y)
 end = time.time()

--- a/python-package/examples/RGF/classification_on_iris_dataset.ipynb
+++ b/python-package/examples/RGF/classification_on_iris_dataset.ipynb
@@ -670,16 +670,16 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "RGF Classfier score: 0.95997\n",
-      "Gradient Boosting Classfier score: 0.95997\n"
+      "RGF Classifier score: 0.95997\n",
+      "Gradient Boosting Classifier score: 0.95997\n"
      ]
     }
    ],
    "source": [
     "rgf_score = sum(rgf_scores)/n_folds\n",
-    "print('RGF Classfier score: {0:.5f}'.format(rgf_score))\n",
+    "print('RGF Classifier score: {0:.5f}'.format(rgf_score))\n",
     "gb_score = sum(gb_scores)/n_folds\n",
-    "print('Gradient Boosting Classfier score: {0:.5f}'.format(gb_score))"
+    "print('Gradient Boosting Classifier score: {0:.5f}'.format(gb_score))"
    ]
   },
   {

--- a/python-package/examples/RGF/comparison_RGF_and_GBM_classifiers_on_iris_dataset.py
+++ b/python-package/examples/RGF/comparison_RGF_and_GBM_classifiers_on_iris_dataset.py
@@ -32,9 +32,9 @@ gb_scores = cross_val_score(gb,
                             cv=StratifiedKFold(n_folds))
 
 rgf_score = sum(rgf_scores)/n_folds
-print('RGF Classfier score: {0:.5f}'.format(rgf_score))
-# >>>RGF Classfier score: 0.95997
+print('RGF Classifier score: {0:.5f}'.format(rgf_score))
+# >>>RGF Classifier score: 0.95997
 
 gb_score = sum(gb_scores)/n_folds
-print('Gradient Boosting Classfier score: {0:.5f}'.format(gb_score))
-# >>>Gradient Boosting Classfier score: 0.95997
+print('Gradient Boosting Classifier score: {0:.5f}'.format(gb_score))
+# >>>Gradient Boosting Classifier score: 0.95997


### PR DESCRIPTION
```
tests/test_examples.py::TestExamples::test_examples
  /home/travis/miniconda/envs/test-environment/lib/python2.7/site-packages/sklearn/ensemble/forest.py:248: FutureWarning: The default value of n_estimators will change from 10 in version 0.20 to 100 in 0.22.
    "10 in version 0.20 to 100 in 0.22.", FutureWarning)
```