### PR TITLE
specify gcc path for R and install only 64-bit R

### DIFF
--- a/R-package/.R.appveyor.ps1
+++ b/R-package/.R.appveyor.ps1
@@ -14,10 +14,11 @@ cd $env:APPVEYOR_BUILD_FOLDER
 [Void][System.IO.Directory]::CreateDirectory($env:R_LIB_PATH)
 
 $env:PATH = "$env:R_LIB_PATH\Rtools\bin;" + "$env:R_LIB_PATH\R\bin\x64;" + "$env:R_LIB_PATH\miktex\texmfs\install\miktex\bin;" + $env:PATH
+$env:BINPREF = "C:/mingw-w64/x86_64-6.3.0-posix-seh-rt_v5-rev1/mingw64/bin/"
 
 if (!(Get-Command R.exe -errorAction SilentlyContinue)) {
     appveyor DownloadFile https://cloud.r-project.org/bin/windows/base/R-3.5.1-win.exe -FileName ./R-win.exe
-    Start-Process -FilePath .\R-win.exe -NoNewWindow -Wait -ArgumentList "/VERYSILENT /DIR=$env:R_LIB_PATH\R"
+    Start-Process -FilePath .\R-win.exe -NoNewWindow -Wait -ArgumentList "/VERYSILENT /DIR=$env:R_LIB_PATH\R /COMPONENTS=main,x64"
 
     appveyor DownloadFile https://cloud.r-project.org/bin/windows/Rtools/Rtools35.exe -FileName ./Rtools.exe
     Start-Process -FilePath .\Rtools.exe -NoNewWindow -Wait -ArgumentList "/VERYSILENT /DIR=$env:R_LIB_PATH\Rtools"


### PR DESCRIPTION
Hotfix for failing `master` branch (when R packages need to be compiled).


```
The downloaded binary packages are in
	C:\Users\appveyor\AppData\Local\Temp\1\RtmpEvKPBb\downloaded_packages
jsonlite (NA -> 1.6) [CRAN]
markdown (NA -> 0.9) [CRAN]
Rscript : Installing 2 packages: jsonlite, markdown
At C:\projects\rgf\R-package\.R.appveyor.ps1:48 char:1

+ Rscript -e "devtools::install_deps(pkg = '.', dependencies = TRUE)"
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : NotSpecified: (Installing 2 pa...nlite, markdown:String) [], RemoteException
    + FullyQualifiedErrorId : NativeCommandError
  There are binary versions available but the source versions are later:
         binary source needs_compilation
jsonlite    1.5    1.6              TRUE
markdown    0.8    0.9              TRUE
installing the source packages 'jsonlite', 'markdown'
trying URL 'https://cran.rstudio.com/src/contrib/jsonlite_1.6.tar.gz'
Content type 'application/x-gzip'
 length 1052728 bytes (1.0 MB)
downloaded 1.0 MB
trying URL 'https://cran.rstudio.com/src/contrib/markdown_0.9.tar.gz'
Content type 'application/x-gzip'
 length 80926 bytes (79 KB)
downloaded 79 KB
* installing *source* package 'jsonlite' ...
** package 'jsonlite' successfully unpacked and MD5 sums checked
** libs
*** arch - i386
c:/Rtools/mingw_32/bin/gcc  -I"C:/RLibrary/R/include" -DNDEBUG -Iyajl/api       -D__USE_MINGW_ANSI_STDIO   -O3 -Wall  -std=gnu99 -mtune=generic -c base64.c -o base64.o

sh: c:/Rtools/mingw_32/bin/gcc: No such file or directory
make: *** [C:/RLibrary/R/etc/i386/Makeconf:208: base64.o] Error 127
ERROR: compilation failed for package 'jsonlite'

* removing 'C:/RLibrary/R/library/jsonlite'

In R CMD INSTALL

Error in i.p(...) : 
  (converted from warning) installation of package 'jsonlite' had non-zero exit status

Calls: <Anonymous> ... with_rprofile_user -> with_envvar -> force -> force -> i.p
Execution halted
```