### PR TITLE
CI fixes

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -58,9 +58,9 @@ test_script:
   - ps: >-
       if($env:TASK -eq "R_PACKAGE") {
           cd $env:APPVEYOR_BUILD_FOLDER;
-          Get-ChildItem env: | Export-CliXml ./env-vars.clixml;
-          powershell -ExecutionPolicy Bypass -File .\R-package\.R.appveyor.ps1
+          Get-ChildItem env: | Export-CliXml ./env-vars.clixml
       }
+  - IF "%TASK%" == "R_PACKAGE" powershell.exe -ExecutionPolicy Bypass -File .\R-package\.R.appveyor.ps1
 
 after_test:
   - ps: >-

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -59,7 +59,7 @@ test_script:
       if($env:TASK -eq "R_PACKAGE") {
           cd $env:APPVEYOR_BUILD_FOLDER;
           Get-ChildItem env: | Export-CliXml ./env-vars.clixml;
-          & .\R-package\.R.appveyor.ps1
+          powershell -ExecutionPolicy Bypass -File .\R-package\.R.appveyor.ps1
       }
 
 after_test:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,3 @@
-sudo: false
-
 # Travis CI does not currently support Python on macOS
 language: generic
 
@@ -21,7 +19,6 @@ env:
 
 before_install:
   - if [[ $TRAVIS_OS_NAME == "osx" ]]; then
-      export HOMEBREW_LOGS="$HOME/brew_logs";
       brew link --overwrite gcc;
       export CXX=g++-8 && export CC=gcc-8;
       curl https://repo.continuum.io/miniconda/Miniconda${PYTHON_VERSION:0:1}-latest-MacOSX-x86_64.sh -o miniconda.sh;

--- a/R-package/.R.appveyor.ps1
+++ b/R-package/.R.appveyor.ps1
@@ -24,7 +24,7 @@ if (!(Get-Command R.exe -errorAction SilentlyContinue)) {
     Start-Process -FilePath .\Rtools.exe -NoNewWindow -Wait -ArgumentList "/VERYSILENT /DIR=$env:R_LIB_PATH\Rtools"
 
     appveyor DownloadFile https://miktex.org/download/ctan/systems/win32/miktex/setup/windows-x86/miktex-portable.exe -FileName ./miktex-portable.exe
-    7z x .\miktex-portable.exe -o"$env:R_LIB_PATH\miktex" -y > $nul
+    7z x .\miktex-portable.exe -o"$env:R_LIB_PATH\miktex" -y > $null
 }
 
 initexmf --set-config-value [MPM]AutoInstall=1

--- a/R-package/.R.appveyor.ps1
+++ b/R-package/.R.appveyor.ps1
@@ -1,7 +1,7 @@
 function Check-Output {
-    param( [int]$ExitCode )
-    if ($ExitCode -ne 0) {
-        $host.SetShouldExit($ExitCode)
+    param( [bool]$Success )
+    if (!$Success) {
+        $host.SetShouldExit(-1)
         Exit -1
     }
 }
@@ -48,16 +48,16 @@ Rscript -e "update.packages(ask = FALSE, instlib = Sys.getenv('R_LIB_PATH'))"
 
 Rscript -e "devtools::install_deps(pkg = '.', dependencies = TRUE)"
 
-R.exe CMD build . ; Check-Output $LastExitCode
+R.exe CMD build . ; Check-Output $?
 
 $PKG_FILE_NAME = Get-Item *.tar.gz
 $PKG_NAME = $PKG_FILE_NAME.BaseName.split("_")[0]
 $LOG_FILE_NAME = "$PKG_NAME.Rcheck/00check.log"
 
-R.exe CMD check "${PKG_FILE_NAME}" --as-cran ; Check-Output $LastExitCode
+R.exe CMD check "${PKG_FILE_NAME}" --as-cran ; Check-Output $?
 if (Get-Content "$LOG_FILE_NAME" | Select-String -Pattern "WARNING") {
     echo "WARNINGS have been found in the build log!"
-    Check-Output -1
+    Check-Output $False
 }
 
 Rscript -e "covr::codecov(quiet = FALSE)"

--- a/R-package/.R.appveyor.ps1
+++ b/R-package/.R.appveyor.ps1
@@ -17,7 +17,7 @@ $env:PATH = "$env:R_LIB_PATH\Rtools\bin;" + "$env:R_LIB_PATH\R\bin\x64;" + "$env
 $env:BINPREF = "C:/mingw-w64/x86_64-6.3.0-posix-seh-rt_v5-rev1/mingw64/bin/"
 
 if (!(Get-Command R.exe -errorAction SilentlyContinue)) {
-    appveyor DownloadFile https://cloud.r-project.org/bin/windows/base/R-3.5.1-win.exe -FileName ./R-win.exe
+    appveyor DownloadFile https://cloud.r-project.org/bin/windows/base/R-3.5.2-win.exe -FileName ./R-win.exe
     Start-Process -FilePath .\R-win.exe -NoNewWindow -Wait -ArgumentList "/VERYSILENT /DIR=$env:R_LIB_PATH\R /COMPONENTS=main,x64"
 
     appveyor DownloadFile https://cloud.r-project.org/bin/windows/Rtools/Rtools35.exe -FileName ./Rtools.exe

--- a/R-package/.R.travis.sh
+++ b/R-package/.R.travis.sh
@@ -12,7 +12,7 @@ if [[ $TRAVIS_OS_NAME == "linux" ]]; then
     sudo apt-get install texlive-latex-recommended texlive-fonts-recommended texlive-fonts-extra qpdf
 
     if ! command -v R &> /dev/null; then
-        R_VER=3.5.1
+        R_VER=3.5.2
         cd $TRAVIS_BUILD_DIR
         wget https://cran.r-project.org/src/base/R-3/R-$R_VER.tar.gz
         tar -xzf R-$R_VER.tar.gz


### PR DESCRIPTION
- Use `cmd` instead of `ps` to fix logging (see screenshots below) and (the most important) fix that warnings cause failures.
- `sudo` for Travis is deprecated now: https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration.
- `HOMEBREW_LOGS` is not needed anymore (refer to #275).
- `$?` seems to be more reliable rather than `$LastExitCode`: https://stackoverflow.com/questions/10666035/difference-between-and-lastexitcode-in-powershell.
- Update R to 3.5.2 (fix 404 error on Appveyor).
- Fix typo `$nul` -> `$null`.



Before (powershell):

![image](https://user-images.githubusercontent.com/25141164/52125918-fadb1380-263e-11e9-8879-f7298d8b5b44.png)


After (powershell from cmd):

![image](https://user-images.githubusercontent.com/25141164/52125965-1514f180-263f-11e9-9b09-744b5cf4e096.png)

