### PR TITLE
fixed file extensions for Windows

### DIFF
--- a/python-package/rgf/fastrgf_model.py
+++ b/python-package/rgf/fastrgf_model.py
@@ -534,7 +534,8 @@ class FastRGFExecuter(utils.CommonRGFExecuterBase):
         params.append("set.verbose=%s" % self.verbose)
         params.append("model.save=%s" % self._model_file_loc)
 
-        cmd = [os.path.join(self.config.FASTRGF_PATH, "forest_train")]
+        cmd = [os.path.join(self.config.FASTRGF_PATH,
+                            self.config.FASTRGF_TRAIN_EXECUTABLE_FILE)]
         cmd.extend(params)
 
         return cmd
@@ -556,7 +557,8 @@ class FastRGFExecuter(utils.CommonRGFExecuterBase):
         params.append("set.nthreads=%s" % self.n_jobs)
         params.append("set.verbose=%s" % self.verbose)
 
-        cmd = [os.path.join(self.config.FASTRGF_PATH, "forest_predict")]
+        cmd = [os.path.join(self.config.FASTRGF_PATH,
+                            self.config.FASTRGF_PREDICT_EXECUTABLE_FILE)]
         cmd.extend(params)
 
         return cmd

--- a/python-package/rgf/utils.py
+++ b/python-package/rgf/utils.py
@@ -57,6 +57,11 @@ class Config(object):
     TEMP_PATH = None
     CURRENT_DIR = os.path.abspath(os.path.dirname(__file__))
 
+    (FASTRGF_TRAIN_EXECUTABLE_FILE,
+     FASTRGF_PREDICT_EXECUTABLE_FILE) = (("forest_train.exe", "forest_predict.exe")
+                                         if SYSTEM in ('Windows', 'Microsoft')
+                                         else ("forest_train", "forest_predict"))
+
     RGF_AVAILABLE = None
     FASTRGF_AVAILABLE = None
 

--- a/python-package/setup.py
+++ b/python-package/setup.py
@@ -118,7 +118,8 @@ def is_fastrgf_response(path):
     temp_y_loc = os.path.join(CURRENT_DIR, 'temp_fastrgf.train.data.y')
     temp_model_loc = os.path.join(CURRENT_DIR, "temp_fastrgf.model")
     temp_pred_loc = os.path.join(CURRENT_DIR, "temp_fastrgf.predictions.txt")
-    path_train = os.path.join(path, "forest_train")
+    path_train = os.path.join(path, ("forest_train.exe" if system() in ('Windows', 'Microsoft')
+                                     else "forest_train"))
     params_train = []
     params_train.append("forest.ntrees=%s" % 10)
     params_train.append("tst.target=%s" % "BINARY")
@@ -127,7 +128,8 @@ def is_fastrgf_response(path):
     params_train.append("model.save=%s" % temp_model_loc)
     cmd_train = [path_train]
     cmd_train.extend(params_train)
-    path_pred = os.path.join(path, "forest_predict")
+    path_pred = os.path.join(path, ("forest_predict.exe" if system() in ('Windows', 'Microsoft')
+                                    else "forest_predict"))
     params_pred = []
     params_pred.append("model.load=%s" % temp_model_loc)
     params_pred.append("tst.x-file=%s" % temp_x_loc)


### PR DESCRIPTION
Fixed #290.

While `.exe` is not needed for Windows when we call this file, it's critical for some other file manipulations. For instance, it's needed for granting permissions (yeah, that fix was introduced for Linux, but why not to try it on Windows too?)

>If you call an exe, you can exclude the ".exe", but my assumption is that since we are performing an operation on a file we need the entire filename including extension.