### PR TITLE
update gcc version and fix miktex installation

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -35,7 +35,7 @@ install:
   - ps: >-
       if($env:PLATFORM -eq "x64") {
           $env:MINICONDA += "-x64";
-          $env:PATH += ";C:\mingw-w64\x86_64-6.3.0-posix-seh-rt_v5-rev1\mingw64\bin"
+          $env:PATH += ";C:\mingw-w64\x86_64-8.1.0-posix-seh-rt_v6-rev0\mingw64\bin"
       }
       else {$env:PATH += ";C:\mingw-w64\i686-6.3.0-posix-dwarf-rt_v5-rev1\mingw32\bin"}
   - set PATH=%MINICONDA%;%MINICONDA%\Scripts;%PATH%

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,8 @@ env:
 before_install:
   - if [[ $TRAVIS_OS_NAME == "osx" ]]; then
       brew link --overwrite gcc;
-      export CXX=g++-8 && export CC=gcc-8;
+      brew upgrade gcc;
+      export CXX=g++-9 && export CC=gcc-9;
       curl https://repo.continuum.io/miniconda/Miniconda${PYTHON_VERSION:0:1}-latest-MacOSX-x86_64.sh -o miniconda.sh;
     else
       sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test;

--- a/R-package/.R.appveyor.ps1
+++ b/R-package/.R.appveyor.ps1
@@ -13,8 +13,8 @@ cd $env:APPVEYOR_BUILD_FOLDER
 
 [Void][System.IO.Directory]::CreateDirectory($env:R_LIB_PATH)
 
-$env:PATH = "$env:R_LIB_PATH\Rtools\bin;" + "$env:R_LIB_PATH\R\bin\x64;" + "$env:R_LIB_PATH\miktex\texmfs\install\miktex\bin;" + $env:PATH
-$env:BINPREF = "C:/mingw-w64/x86_64-6.3.0-posix-seh-rt_v5-rev1/mingw64/bin/"
+$env:PATH = "$env:R_LIB_PATH\Rtools\bin;" + "$env:R_LIB_PATH\R\bin\x64;" + "$env:R_LIB_PATH\miktex\texmfs\install\miktex\bin\x64;" + $env:PATH
+$env:BINPREF = "C:/mingw-w64/x86_64-8.1.0-posix-seh-rt_v6-rev0/mingw64/bin/"
 
 if (!(Get-Command R.exe -errorAction SilentlyContinue)) {
     appveyor DownloadFile https://cloud.r-project.org/bin/windows/base/R-3.6.0-win.exe -FileName ./R-win.exe
@@ -23,8 +23,11 @@ if (!(Get-Command R.exe -errorAction SilentlyContinue)) {
     appveyor DownloadFile https://cloud.r-project.org/bin/windows/Rtools/Rtools35.exe -FileName ./Rtools.exe
     Start-Process -FilePath .\Rtools.exe -NoNewWindow -Wait -ArgumentList "/VERYSILENT /DIR=$env:R_LIB_PATH\Rtools"
 
-    appveyor DownloadFile https://miktex.org/download/ctan/systems/win32/miktex/setup/windows-x86/miktex-portable.exe -FileName ./miktex-portable.exe
-    7z x .\miktex-portable.exe -o"$env:R_LIB_PATH\miktex" -y > $null
+    appveyor DownloadFile https://miktex.org/download/win/miktexsetup-x64.zip -FileName ./miktexsetup-x64.zip
+    Add-Type -AssemblyName System.IO.Compression.FileSystem
+    [System.IO.Compression.ZipFile]::ExtractToDirectory("miktexsetup-x64.zip", "miktex")
+    .\miktex\miktexsetup.exe --local-package-repository=.\miktex\download --package-set=essential --quiet download
+    .\miktex\download\miktexsetup.exe --portable="$env:R_LIB_PATH\miktex" --quiet install
 }
 
 initexmf --set-config-value [MPM]AutoInstall=1

--- a/python-package/Readme.rst
+++ b/python-package/Readme.rst
@@ -74,6 +74,8 @@ or from `GitHub <https://github.com/RGF-team/rgf/python-package>`__:
     cd rgf/python-package
     python setup.py install
 
+MacOS users, **rgf\_python** after the ``3.5.0`` version is built with **g++-9** and cannot be launched on systems with **g++-8** and earlier. You should update your **g++** compiler if you don't want to build from sources or install **rgf\_python** ``3.5.0`` from PyPI which is the last version built with **g++-8**.
+
 MacOS users, **rgf\_python** after the ``3.1.0`` version is built with **g++-8** and cannot be launched on systems with **g++-7** and earlier. You should update your **g++** compiler if you don't want to build from sources or install **rgf\_python** ``3.1.0`` from PyPI which is the last version built with **g++-7**.
 
 If you have any problems while installing by methods listed above, you should *build RGF and FastRGF executable files from binaries on your own and place compiled executable files* into directory which is included in environmental variable **'PATH'** or into directory with installed package. Alternatively, you may specify actual locations of executable files and directory for placing temp files by corresponding flags in configuration file ``.rgfrc``, which you should create into your home directory. The default values are the following: ``rgf_location=$HOME/rgf`` (``$HOME/rgf.exe`` for Windows), ``fastrgf_location=$HOME``, ``temp_location=tempfile.gettempdir()`` (here is more details about `tempfile.gettempdir() <https://docs.python.org/3/library/tempfile.html#tempfile.gettempdir>`__). Please take a look at the example of the ``.rgfrc`` file:

--- a/python-package/setup.py
+++ b/python-package/setup.py
@@ -252,7 +252,7 @@ def compile_fastrgf():
         if tmp_result or system() in ('Windows', 'Microsoft'):
             return tmp_result
 
-        for version in range(5, 9):
+        for version in range(5, 10):
             try:
                 subprocess.check_output(('g++-' + str(version), '--version'))
                 return True


### PR DESCRIPTION
- Use higher gcc version for tests on Windows 64-bit.
- Allow compilation with gcc-9 and compile with it on macOS. https://gcc.gnu.org/gcc-9/changes.html
- Update Miktex installation: https://miktex.org/announcement/miktex-portable-sfx-discontinued.