### PR TITLE
Embedded debug message.

### DIFF
--- a/python-package/rgf/utils.py
+++ b/python-package/rgf/utils.py
@@ -154,7 +154,7 @@ class Config(object):
     @classmethod
     def is_fastrgf_executable(cls, path, verbose=False):
         if verbose:
-            print("[FastRGF] investigate {}".format(path))
+            print("[FastRGF] Investigate {}".format(path))
         temp_x_loc = os.path.join(cls.TEMP_PATH, 'temp_fastrgf.train.data.x')
         temp_y_loc = os.path.join(cls.TEMP_PATH, 'temp_fastrgf.train.data.y')
         temp_model_loc = os.path.join(cls.TEMP_PATH, "temp_fastrgf.model")

--- a/python-package/rgf/utils.py
+++ b/python-package/rgf/utils.py
@@ -65,11 +65,11 @@ class Config(object):
     RGF_AVAILABLE = None
     FASTRGF_AVAILABLE = None
 
-    def __init__(self):
+    def __init__(self, verbose=False):
         (self.DEFAULT_RGF_PATH, self.RGF_PATH,
          self.DEFAULT_FASTRGF_PATH, self.FASTRGF_PATH, self.TEMP_PATH) = self.init_paths()
         (self.RGF_PATH, self.RGF_AVAILABLE,
-         self.FASTRGF_PATH, self.FASTRGF_AVAILABLE) = self.set_paths_and_availability()
+         self.FASTRGF_PATH, self.FASTRGF_AVAILABLE) = self.set_paths_and_availability(verbose)
 
     @classmethod
     def init_paths(cls):
@@ -152,7 +152,9 @@ class Config(object):
         return True
 
     @classmethod
-    def is_fastrgf_executable(cls, path):
+    def is_fastrgf_executable(cls, path, verbose=False):
+        if verbose:
+            print("[FastRgf] investigate {}".format(path))
         temp_x_loc = os.path.join(cls.TEMP_PATH, 'temp_fastrgf.train.data.x')
         temp_y_loc = os.path.join(cls.TEMP_PATH, 'temp_fastrgf.train.data.y')
         temp_model_loc = os.path.join(cls.TEMP_PATH, "temp_fastrgf.model")
@@ -186,12 +188,18 @@ class Config(object):
         try:
             subprocess.check_output(cmd_train, stderr=subprocess.STDOUT)
             subprocess.check_output(cmd_pred, stderr=subprocess.STDOUT)
-        except Exception:
+        except Exception as e:
+            if verbose:
+                print(e)
             return False
+
+        if verbose:
+            print("[FastRgf] Found in {}".format(path))
+
         return True
 
     @classmethod
-    def set_paths_and_availability(cls):
+    def set_paths_and_availability(cls, verbose=False):
         if cls.RGF_AVAILABLE is None or cls.FASTRGF_AVAILABLE is None:
             cls.RGF_AVAILABLE = True
             if cls.is_rgf_executable(os.path.join(cls.CURRENT_DIR, cls.DEFAULT_RGF_PATH)):
@@ -206,11 +214,11 @@ class Config(object):
                               "RGF estimators will be unavailable for usage.")
 
             cls.FASTRGF_AVAILABLE = True
-            if cls.is_fastrgf_executable(cls.CURRENT_DIR):
+            if cls.is_fastrgf_executable(cls.CURRENT_DIR, verbose):
                 cls.FASTRGF_PATH = cls.CURRENT_DIR
-            elif cls.is_fastrgf_executable(cls.DEFAULT_FASTRGF_PATH):
+            elif cls.is_fastrgf_executable(cls.DEFAULT_FASTRGF_PATH, verbose):
                 cls.FASTRGF_PATH = cls.DEFAULT_FASTRGF_PATH
-            elif cls.is_fastrgf_executable(cls.FASTRGF_PATH):
+            elif cls.is_fastrgf_executable(cls.FASTRGF_PATH, verbose):
                 pass
             else:
                 cls.FASTRGF_AVAILABLE = False

--- a/python-package/rgf/utils.py
+++ b/python-package/rgf/utils.py
@@ -154,7 +154,7 @@ class Config(object):
     @classmethod
     def is_fastrgf_executable(cls, path, verbose=False):
         if verbose:
-            print("[FastRgf] investigate {}".format(path))
+            print("[FastRGF] investigate {}".format(path))
         temp_x_loc = os.path.join(cls.TEMP_PATH, 'temp_fastrgf.train.data.x')
         temp_y_loc = os.path.join(cls.TEMP_PATH, 'temp_fastrgf.train.data.y')
         temp_model_loc = os.path.join(cls.TEMP_PATH, "temp_fastrgf.model")
@@ -194,7 +194,7 @@ class Config(object):
             return False
 
         if verbose:
-            print("[FastRgf] Found in {}".format(path))
+            print("[FastRGF] Found in {}".format(path))
 
         return True
 


### PR DESCRIPTION
Unfortunately, sometimes FastRGF causes installation problem.

We can distingish FileNotFound or FilePermission or FastRGF crash with debug message.
This feature is not only for user, but also for us.
It will be helpful for debugging if ci is failed.

Usage is here.
```
>>> import rgf.utils                                                                                                                          
>>> rgf.utils.Config(True)                                                                                                                    
/home/ryo/work/github/rgf_python/python-package/rgf/utils.py:213: UserWarning: Cannot find RGF executable file. RGF estimators will be unavailable for usage.
  warnings.warn("Cannot find RGF executable file. "
[FastRgf] investigate /home/ryo/work/github/rgf_python/python-package/rgf
[Errno 2] No such file or directory: '/home/ryo/work/github/rgf_python/python-package/rgf/forest_train': '/home/ryo/work/github/rgf_python/python-package/rgf/forest_train'
[FastRgf] investigate 
[Errno 2] No such file or directory: 'forest_train': 'forest_train'
[FastRgf] investigate /home/ryo/work/fast_rgf/build/src/exe
[Errno 2] No such file or directory: '/home/ryo/work/fast_rgf/build/src/exe/forest_train': '/home/ryo/work/fast_rgf/build/src/exe/forest_train'
/home/ryo/work/github/rgf_python/python-package/rgf/utils.py:225: UserWarning: Cannot find FastRGF executable files. FastRGF estimators will be unavailable for usage.
  warnings.warn("Cannot find FastRGF executable files. "
<rgf.utils.Config object at 0x7f38b395ef98>
```