### PR TITLE
added one more test to increase R code coverage for sparse matrices

### DIFF
--- a/R-package/tests/testthat/test-RGF_package.R
+++ b/R-package/tests/testthat/test-RGF_package.R
@@ -250,6 +250,16 @@ testthat::test_that("the methods of the 'FastRGF_Classifier' class return the co
 # conversion of an R matrix to a scipy sparse matrix
 #---------------------------------------------------
 
+testthat::test_that("the 'mat_2scipy_sparse' returns an error in case that the data is not inheriting matrix class", {
+
+  skip_test_if_no_module("scipy")
+
+  x_rgf_invalid = as.data.frame(x_rgf)
+
+  testthat::expect_error( mat_2scipy_sparse(x_rgf_invalid) )
+})
+
+
 testthat::test_that("the 'mat_2scipy_sparse' returns an error in case that the 'format' parameter is invalid", {
 
   skip_test_if_no_module("scipy")


### PR DESCRIPTION
Related to #269.

Sorry, forgot to add this test in #311.

Now sparse module has 100% coverage.