### PR TITLE
Use CMAKE_INSTALL_PREFIX

### DIFF
--- a/FastRGF/src/exe/CMakeLists.txt
+++ b/FastRGF/src/exe/CMakeLists.txt
@@ -21,9 +21,9 @@ target_link_libraries(discretized_trainer base forest)
 add_executable(forest_train forest_train.cpp) 
 target_link_libraries(forest_train forest base)
 
-install(TARGETS forest_train DESTINATION ${CMAKE_SOURCE_DIR}/bin)
+install(TARGETS forest_train DESTINATION bin)
 
 add_executable(forest_predict forest_predict.cpp) 
 target_link_libraries(forest_predict forest base)
 
-install(TARGETS forest_predict DESTINATION ${CMAKE_SOURCE_DIR}/bin)
+install(TARGETS forest_predict DESTINATION bin)


### PR DESCRIPTION
Hey, thanks for this project! <strike>Currently, `CMAKE_INSTALL_PREFIX` is respected for RGF, but not for FastRGF.</strike> This allows `CMAKE_INSTALL_PREFIX` to work for FastRGF.

```sh
mkdir FastRGF/build
cd FastRGF/build
cmake .. -DCMAKE_INSTALL_PREFIX=/tmp
make install
```