### PR TITLE
[ci] changed strategy for installing R on AppVeyor

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -15,6 +15,7 @@ environment:
     - PYTHON_VERSION: 3.7
     - PYTHON_VERSION: 3.8
     - PYTHON_VERSION: 3.8
+      R_VERSION: 3.6.2
       TASK: R_PACKAGE
 
 matrix:

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -15,7 +15,6 @@ environment:
     - PYTHON_VERSION: 3.7
     - PYTHON_VERSION: 3.8
     - PYTHON_VERSION: 3.8
-      R_VERSION: 3.6.2
       TASK: R_PACKAGE
 
 matrix:

--- a/R-package/.R.appveyor.ps1
+++ b/R-package/.R.appveyor.ps1
@@ -18,7 +18,8 @@ $env:BINPREF = "C:/mingw-w64/x86_64-8.1.0-posix-seh-rt_v6-rev0/mingw64/bin/"
 
 if (!(Get-Command R.exe -errorAction SilentlyContinue)) {
 
-    appveyor DownloadFile https://cloud.r-project.org/bin/windows/base/old/$env:R_VERSION/R-$env:R_VERSION-win.exe -FileName ./R-win.exe
+    $R_VER="3.6.2"
+    appveyor DownloadFile https://cloud.r-project.org/bin/windows/base/old/$R_VER/R-$R_VER-win.exe -FileName ./R-win.exe
     Start-Process -FilePath .\R-win.exe -NoNewWindow -Wait -ArgumentList "/VERYSILENT /DIR=$env:R_LIB_PATH\R /COMPONENTS=main,x64"
 
     appveyor DownloadFile https://cloud.r-project.org/bin/windows/Rtools/Rtools35.exe -FileName ./Rtools.exe

--- a/R-package/.R.appveyor.ps1
+++ b/R-package/.R.appveyor.ps1
@@ -17,7 +17,8 @@ $env:PATH = "$env:R_LIB_PATH\Rtools\bin;" + "$env:R_LIB_PATH\R\bin\x64;" + "$env
 $env:BINPREF = "C:/mingw-w64/x86_64-8.1.0-posix-seh-rt_v6-rev0/mingw64/bin/"
 
 if (!(Get-Command R.exe -errorAction SilentlyContinue)) {
-    appveyor DownloadFile https://cloud.r-project.org/bin/windows/base/R-3.6.2-win.exe -FileName ./R-win.exe
+
+    appveyor DownloadFile https://cloud.r-project.org/bin/windows/base/old/$env:R_VERSION/R-$env:R_VERSION-win.exe -FileName ./R-win.exe
     Start-Process -FilePath .\R-win.exe -NoNewWindow -Wait -ArgumentList "/VERYSILENT /DIR=$env:R_LIB_PATH\R /COMPONENTS=main,x64"
 
     appveyor DownloadFile https://cloud.r-project.org/bin/windows/Rtools/Rtools35.exe -FileName ./Rtools.exe


### PR DESCRIPTION
@StrikerRUS while working on https://github.com/microsoft/LightGBM/pull/2936, I noticed that in this repo you're using a link like this to get `R.exe`:

```
appveyor DownloadFile https://cloud.r-project.org/bin/windows/base/R-${R_VERSION}-win.exe
```

I think that those links only work as long as that version is the latest release. In this PR, I propose changing to the `/old` URLs which you can rely on forever (so you can upgrade at your own pace).