### PR TITLE
fix two warnings from sklearn

### DIFF
--- a/python-package/rgf/utils.py
+++ b/python-package/rgf/utils.py
@@ -559,6 +559,7 @@ class RGFClassifierMixin(object):
             raise ValueError("Classifier can't predict when only one class is present.")
 
         self._fitted = True
+        self.n_features_in_ = self._n_features
 
         return self
 
@@ -663,6 +664,7 @@ class RGFRegressorMixin(object):
         self._fit_regression_task(X, y, sample_weight, params)
 
         self._fitted = True
+        self.n_features_in_ = self._n_features
 
         return self
 

--- a/python-package/tests/test_rgf_python.py
+++ b/python-package/tests/test_rgf_python.py
@@ -23,7 +23,7 @@ from rgf.utils import cleanup, Config
 
 class EstimatorBaseTest(object):
     def test_sklearn_integration(self):
-        check_estimator(self.estimator_class)
+        check_estimator(self.estimator_class())
 
     def test_input_arrays_shape(self):
         est = self.estimator_class(**self.kwargs)
@@ -489,7 +489,7 @@ class TestFastRGFClassifier(ClassifierBaseTest, FastRGFBaseTest, unittest.TestCa
     def test_sklearn_integration(self):
         # TODO(fukatani): FastRGF bug?
         # FastRGF doesn't work if the number of sample is too small.
-        # check_estimator(self.estimator_class)
+        # check_estimator(self.estimator_class())
         pass
 
 
@@ -541,5 +541,5 @@ class TestFastRGFRegressor(RegressorBaseTest, FastRGFBaseTest, unittest.TestCase
     def test_sklearn_integration(self):
         # TODO(fukatani): FastRGF bug?
         # FastRGF doesn't work if the number of sample is too small.
-        # check_estimator(self.estimator_class)
+        # check_estimator(self.estimator_class())
         pass


### PR DESCRIPTION
```
tests/test_rgf_python.py::TestRGFClassifier::test_sklearn_integration
tests/test_rgf_python.py::TestRGFRegressor::test_sklearn_integration
  /home/travis/miniconda/envs/test-environment/lib/python3.6/site-packages/sklearn/utils/estimator_checks.py:488: FutureWarning: Passing a class is deprecated since version 0.23 and won't be supported in 0.24.Please pass an instance instead.
    warnings.warn(msg, FutureWarning)
tests/test_rgf_python.py::TestRGFClassifier::test_sklearn_integration
tests/test_rgf_python.py::TestRGFRegressor::test_sklearn_integration
  /home/travis/miniconda/envs/test-environment/lib/python3.6/site-packages/sklearn/utils/estimator_checks.py:3014: FutureWarning: As of scikit-learn 0.23, estimators should expose a n_features_in_ attribute, unless the 'no_validation' tag is True. This attribute should be equal to the number of features passed to the fit method. An error will be raised from version 0.25 when calling check_estimator(). See SLEP010: https://scikit-learn-enhancement-proposals.readthedocs.io/en/latest/slep010/proposal.html
    FutureWarning
```