### PR TITLE
Support latest scikit-learn (>=0.24) and Python 3.9

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -9,17 +9,14 @@ environment:
   global:
     R_LIB_PATH: C:\RLibrary
   matrix:
-    - PYTHON_VERSION: 2.7
-    - PYTHON_VERSION: 3.6
-    - PYTHON_VERSION: 3.7
-    - PYTHON_VERSION: 3.8
-    - PYTHON_VERSION: 3.8
+    - PYTHON_VERSION: 3.9
+    - PYTHON_VERSION: 3.9
       TASK: R_PACKAGE
 
 matrix:
   exclude:
     - platform: x86
-      PYTHON_VERSION: 3.8
+      PYTHON_VERSION: 3.9
       TASK: R_PACKAGE
 
 install:
@@ -61,7 +58,7 @@ after_test:
       if(
          $env:APPVEYOR_REPO_TAG -eq "false" -or
          $env:APPVEYOR_REPO_BRANCH -ne "master" -or
-         $env:PYTHON_VERSION -ne "3.8" -or
+         $env:PYTHON_VERSION -ne "3.9" -or
          $env:TASK -eq "R_PACKAGE") {
           Exit-AppVeyorBuild
       }
@@ -95,4 +92,4 @@ deploy:
   on:
     appveyor_repo_tag: true
     branch: master
-    PYTHON_VERSION: 3.8
+    PYTHON_VERSION: 3.9

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -9,6 +9,10 @@ environment:
   global:
     R_LIB_PATH: C:\RLibrary
   matrix:
+    - PYTHON_VERSION: 2.7
+    - PYTHON_VERSION: 3.6
+    - PYTHON_VERSION: 3.7
+    - PYTHON_VERSION: 3.8
     - PYTHON_VERSION: 3.9
     - PYTHON_VERSION: 3.9
       TASK: R_PACKAGE

--- a/.ci/python_tests.sh
+++ b/.ci/python_tests.sh
@@ -35,6 +35,6 @@ fi
 cd $GITHUB_WORKSPACE/python-package
 python setup.py sdist --formats gztar || exit -1
 pip install dist/rgf_python-$RGF_VER.tar.gz -v || exit -1
-if [[ $TASK != "R_PACKAGE" ]]; then
-  pytest tests/ -v || exit -1
-fi
+#if [[ $TASK != "R_PACKAGE" ]]; then
+pytest tests/ -v || exit -1
+#fi

--- a/.ci/python_tests.sh
+++ b/.ci/python_tests.sh
@@ -35,6 +35,6 @@ fi
 cd $GITHUB_WORKSPACE/python-package
 python setup.py sdist --formats gztar || exit -1
 pip install dist/rgf_python-$RGF_VER.tar.gz -v || exit -1
-#if [[ $TASK != "R_PACKAGE" ]]; then
-pytest tests/ -v || exit -1
-#fi
+if [[ $TASK != "R_PACKAGE" ]]; then
+  pytest tests/ -v || exit -1
+fi

--- a/.ci/python_tests.sh
+++ b/.ci/python_tests.sh
@@ -27,7 +27,7 @@ conda update -q conda
 if [[ $TASK == "R_PACKAGE" ]]; then
   conda create -q -n $CONDA_ENV python=$PYTHON_VERSION pip openssl libffi --no-deps
   source activate $CONDA_ENV
-  pip install setuptools joblib numpy scikit-learn scipy pandas wheel pytest
+  pip install setuptools joblib numpy scikit-learn scipy pandas wheel
 else
   conda create -q -n $CONDA_ENV python=$PYTHON_VERSION joblib numpy scikit-learn scipy pandas pytest
   source activate $CONDA_ENV

--- a/.ci/python_tests.sh
+++ b/.ci/python_tests.sh
@@ -27,7 +27,7 @@ conda update -q conda
 if [[ $TASK == "R_PACKAGE" ]]; then
   conda create -q -n $CONDA_ENV python=$PYTHON_VERSION pip openssl libffi --no-deps
   source activate $CONDA_ENV
-  pip install setuptools joblib numpy scikit-learn scipy pandas wheel
+  pip install setuptools joblib numpy scikit-learn scipy pandas wheel pytest
 else
   conda create -q -n $CONDA_ENV python=$PYTHON_VERSION joblib numpy scikit-learn scipy pandas pytest
   source activate $CONDA_ENV

--- a/.ci/python_tests.sh
+++ b/.ci/python_tests.sh
@@ -27,9 +27,9 @@ conda update -q conda
 if [[ $TASK == "R_PACKAGE" ]]; then
   conda create -q -n $CONDA_ENV python=$PYTHON_VERSION pip openssl libffi --no-deps
   source activate $CONDA_ENV
-  pip install setuptools joblib numpy "scikit-learn<0.24" scipy pandas wheel
+  pip install setuptools joblib numpy scikit-learn scipy pandas wheel
 else
-  conda create -q -n $CONDA_ENV python=$PYTHON_VERSION joblib numpy "scikit-learn<0.24" scipy pandas pytest
+  conda create -q -n $CONDA_ENV python=$PYTHON_VERSION joblib numpy scikit-learn scipy pandas pytest
   source activate $CONDA_ENV
 fi
 cd $GITHUB_WORKSPACE/python-package

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,7 +3,7 @@ name: Python and R tests
 on:
   push:
     branches:
-    - py39
+    - master
   pull_request:
     branches:
     - master

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,7 +3,7 @@ name: Python and R tests
 on:
   push:
     branches:
-    - master
+    - py39
   pull_request:
     branches:
     - master

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,6 +19,21 @@ jobs:
         include:
           - os: ubuntu-latest
             container: ubuntu:trusty
+            python_version: 3.6
+          - os: macos-latest
+            python_version: 3.6
+          - os: ubuntu-latest
+            container: ubuntu:trusty
+            python_version: 3.7
+          - os: macos-latest
+            python_version: 3.7
+          - os: ubuntu-latest
+            container: ubuntu:trusty
+            python_version: 3.8
+          - os: macos-latest
+            python_version: 3.8
+          - os: ubuntu-latest
+            container: ubuntu:trusty
             python_version: 3.9
           - os: macos-latest
             python_version: 3.9

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,25 +19,15 @@ jobs:
         include:
           - os: ubuntu-latest
             container: ubuntu:trusty
-            python_version: 3.6
+            python_version: 3.9
           - os: macos-latest
-            python_version: 3.6
-          - os: ubuntu-latest
-            container: ubuntu:trusty
-            python_version: 3.7
-          - os: macos-latest
-            python_version: 3.7
-          - os: ubuntu-latest
-            container: ubuntu:trusty
-            python_version: 3.8
-          - os: macos-latest
-            python_version: 3.8
+            python_version: 3.9
           - os: ubuntu-latest
             container: rocker/verse:latest
-            python_version: 3.8
+            python_version: 3.9
             task: R_PACKAGE
           - os: macos-latest
-            python_version: 3.8
+            python_version: 3.9
             task: R_PACKAGE
     container: ${{ matrix.container }}
     steps:
@@ -66,7 +56,7 @@ jobs:
             $GITHUB_WORKSPACE/.ci/r_tests.sh || exit -1
           fi
       - name: Create Wheel
-        if: matrix.python_version == 3.8 && matrix.task != 'R_PACKAGE' && github.ref == 'refs/heads/master'
+        if: matrix.python_version == 3.9 && matrix.task != 'R_PACKAGE' && github.ref == 'refs/heads/master'
         shell: bash
         run: |
           export PATH="${{ env.CONDA_PATH }}/bin:$PATH"
@@ -79,7 +69,7 @@ jobs:
             python setup.py bdist_wheel --plat-name=manylinux1_x86_64 --python-tag py3;
           fi
       - name: Create GitHub Release
-        if: matrix.python_version == 3.8 && matrix.task != 'R_PACKAGE' && github.ref == 'refs/heads/master'
+        if: matrix.python_version == 3.9 && matrix.task != 'R_PACKAGE' && github.ref == 'refs/heads/master'
         uses: softprops/action-gh-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/python-package/rgf/fastrgf_model.py
+++ b/python-package/rgf/fastrgf_model.py
@@ -353,8 +353,7 @@ class FastRGFEstimatorBase(utils.CommonRGFEstimatorBase):
                                               sample_weight)
 
 
-class FastRGFRegressor(FastRGFEstimatorBase, RegressorMixin,
-                       utils.RGFRegressorMixin):
+class FastRGFRegressor(RegressorMixin, utils.RGFRegressorMixin, FastRGFEstimatorBase):
     def __init__(self,
                  n_estimators=500,
                  max_depth=6,
@@ -409,8 +408,7 @@ class FastRGFRegressor(FastRGFEstimatorBase, RegressorMixin,
         __doc__ = __doc__.replace(_template, _value)
 
 
-class FastRGFClassifier(FastRGFEstimatorBase, ClassifierMixin,
-                        utils.RGFClassifierMixin):
+class FastRGFClassifier(ClassifierMixin, utils.RGFClassifierMixin, FastRGFEstimatorBase):
     def __init__(self,
                  n_estimators=500,
                  max_depth=6,

--- a/python-package/rgf/rgf_model.py
+++ b/python-package/rgf/rgf_model.py
@@ -454,7 +454,7 @@ class RGFEstimatorBase(utils.CommonRGFEstimatorBase):
         return np.mean([est.feature_importances_ for est in self._estimators], axis=0)
 
 
-class RGFRegressor(RGFEstimatorBase, RegressorMixin, utils.RGFRegressorMixin):
+class RGFRegressor(RegressorMixin, utils.RGFRegressorMixin, RGFEstimatorBase):
     def __init__(self,
                  max_leaf=500,
                  test_interval=100,
@@ -519,7 +519,7 @@ class RGFRegressor(RGFEstimatorBase, RegressorMixin, utils.RGFRegressorMixin):
         save_model.__doc__ = save_model.__doc__.replace(_template, _value)
 
 
-class RGFClassifier(RGFEstimatorBase, ClassifierMixin, utils.RGFClassifierMixin):
+class RGFClassifier(ClassifierMixin, utils.RGFClassifierMixin, RGFEstimatorBase):
     def __init__(self,
                  max_leaf=1000,
                  test_interval=100,

--- a/python-package/rgf/utils.py
+++ b/python-package/rgf/utils.py
@@ -490,6 +490,9 @@ class CommonRGFEstimatorBase(BaseEstimator):
 
 
 class RGFClassifierMixin(object):
+    def _more_tags(self):
+        return {'_xfail_checks': {'check_sample_weights_invariance': 'sample_weight must have positive values'}}
+
     @property
     def classes_(self):
         """The classes labels when `fit` is performed."""
@@ -626,6 +629,9 @@ class RGFClassifierMixin(object):
 
 
 class RGFRegressorMixin(object):
+    def _more_tags(self):
+        return {'_xfail_checks': {'check_sample_weights_invariance': 'sample_weight must have positive values'}}
+
     def fit(self, X, y, sample_weight=None):
         """
         Build a regressor from the training set (X, y).

--- a/python-package/rgf/utils.py
+++ b/python-package/rgf/utils.py
@@ -491,7 +491,8 @@ class CommonRGFEstimatorBase(BaseEstimator):
 
 class RGFClassifierMixin(object):
     def _more_tags(self):
-        return {'_xfail_checks': {'check_sample_weights_invariance': 'sample_weight must have positive values'}}
+        return {'X_types': ['2darray', 'sparse', '1dlabels'],
+                '_xfail_checks': {'check_sample_weights_invariance': 'sample_weight must have positive values'}}
 
     @property
     def classes_(self):
@@ -630,7 +631,8 @@ class RGFClassifierMixin(object):
 
 class RGFRegressorMixin(object):
     def _more_tags(self):
-        return {'_xfail_checks': {'check_sample_weights_invariance': 'sample_weight must have positive values'}}
+        return {'X_types': ['2darray', 'sparse', '1dlabels'],
+                '_xfail_checks': {'check_sample_weights_invariance': 'sample_weight must have positive values'}}
 
     def fit(self, X, y, sample_weight=None):
         """

--- a/python-package/rgf/utils.py
+++ b/python-package/rgf/utils.py
@@ -492,6 +492,7 @@ class CommonRGFEstimatorBase(BaseEstimator):
 class RGFClassifierMixin(object):
     def _more_tags(self):
         return {'X_types': ['2darray', 'sparse', '1dlabels'],
+                'requires_y' : True,
                 '_xfail_checks': {'check_sample_weights_invariance': 'sample_weight must have positive values'}}
 
     @property
@@ -632,6 +633,7 @@ class RGFClassifierMixin(object):
 class RGFRegressorMixin(object):
     def _more_tags(self):
         return {'X_types': ['2darray', 'sparse', '1dlabels'],
+                'requires_y' : True,
                 '_xfail_checks': {'check_sample_weights_invariance': 'sample_weight must have positive values'}}
 
     def fit(self, X, y, sample_weight=None):

--- a/python-package/setup.py
+++ b/python-package/setup.py
@@ -395,4 +395,5 @@ setup(name='rgf_python',
                    'Programming Language :: Python :: 3.6',
                    'Programming Language :: Python :: 3.7',
                    'Programming Language :: Python :: 3.8',
+                   'Programming Language :: Python :: 3.9',
                    'Topic :: Scientific/Engineering :: Artificial Intelligence'])

--- a/python-package/tests/test_rgf_python.py
+++ b/python-package/tests/test_rgf_python.py
@@ -13,7 +13,7 @@ from sklearn.metrics import accuracy_score
 from sklearn.metrics import mean_absolute_error
 from sklearn.metrics import mean_squared_error
 from sklearn.model_selection import GridSearchCV, train_test_split
-from sklearn.utils.estimator_checks import parametrize_with_checks
+from sklearn.utils.estimator_checks import check_estimator
 from sklearn.utils.validation import check_random_state
 
 from rgf.sklearn import RGFClassifier, RGFRegressor

--- a/python-package/tests/test_rgf_python.py
+++ b/python-package/tests/test_rgf_python.py
@@ -23,8 +23,7 @@ from rgf.utils import cleanup, Config
 
 class EstimatorBaseTest(object):
     def test_sklearn_integration(self):
-        for estimator, check in check_estimator(self.estimator_class(), generate_only=True):
-            check(estimator)
+        check_estimator(self.estimator_class())
 
     def test_input_arrays_shape(self):
         est = self.estimator_class(**self.kwargs)

--- a/python-package/tests/test_rgf_python.py
+++ b/python-package/tests/test_rgf_python.py
@@ -13,7 +13,7 @@ from sklearn.metrics import accuracy_score
 from sklearn.metrics import mean_absolute_error
 from sklearn.metrics import mean_squared_error
 from sklearn.model_selection import GridSearchCV, train_test_split
-from sklearn.utils.estimator_checks import check_estimator
+from sklearn.utils.estimator_checks import parametrize_with_checks
 from sklearn.utils.validation import check_random_state
 
 from rgf.sklearn import RGFClassifier, RGFRegressor
@@ -23,7 +23,8 @@ from rgf.utils import cleanup, Config
 
 class EstimatorBaseTest(object):
     def test_sklearn_integration(self):
-        check_estimator(self.estimator_class())
+        for estimator, check in check_estimator(self.estimator_class(), generate_only=True):
+            check(estimator)
 
     def test_input_arrays_shape(self):
         est = self.estimator_class(**self.kwargs)


### PR DESCRIPTION
Workaround changes in the latest scikit-learn version where integration test yields weight array with zeros:
```
__________________ TestRGFClassifier.test_sklearn_integration __________________

self = <test_rgf_python.TestRGFClassifier testMethod=test_sklearn_integration>

    def test_sklearn_integration(self):
>       check_estimator(self.estimator_class())

tests/test_rgf_python.py:26: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
/github/home/miniconda/envs/test-env/lib/python3.9/site-packages/sklearn/utils/estimator_checks.py:547: in check_estimator
    check(estimator)
/github/home/miniconda/envs/test-env/lib/python3.9/site-packages/sklearn/utils/_testing.py:308: in wrapper
    return fn(*args, **kwargs)
/github/home/miniconda/envs/test-env/lib/python3.9/site-packages/sklearn/utils/estimator_checks.py:914: in check_sample_weights_invariance
    estimator2.fit(X2, y=y2, sample_weight=sw2)
/github/home/miniconda/envs/test-env/lib/python3.9/site-packages/rgf/utils.py:537: in fit
    sample_weight = self._get_sample_weight(sample_weight)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = RGFClassifier()
sample_weight = array([1., 0., 1., 1., 0., 1., 0., 0., 0., 1., 0., 1., 0., 1., 0., 0., 0.,
       1., 0., 1., 1., 0., 0., 0., 1., 1., 0., 1., 1., 0., 1., 1.])

    def _get_sample_weight(self, sample_weight):
        if sample_weight is not None:
            sample_weight = column_or_1d(sample_weight, warn=True)
            if (sample_weight <= 0).any():
>               raise ValueError("Sample weights must be positive.")
E               ValueError: Sample weights must be positive.

/github/home/miniconda/envs/test-env/lib/python3.9/site-packages/rgf/utils.py:419: ValueError
__________________ TestRGFRegressor.test_sklearn_integration ___________________

self = <test_rgf_python.TestRGFRegressor testMethod=test_sklearn_integration>

    def test_sklearn_integration(self):
>       check_estimator(self.estimator_class())

tests/test_rgf_python.py:26: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
/github/home/miniconda/envs/test-env/lib/python3.9/site-packages/sklearn/utils/estimator_checks.py:547: in check_estimator
    check(estimator)
/github/home/miniconda/envs/test-env/lib/python3.9/site-packages/sklearn/utils/_testing.py:308: in wrapper
    return fn(*args, **kwargs)
/github/home/miniconda/envs/test-env/lib/python3.9/site-packages/sklearn/utils/estimator_checks.py:914: in check_sample_weights_invariance
    estimator2.fit(X2, y=y2, sample_weight=sw2)
/github/home/miniconda/envs/test-env/lib/python3.9/site-packages/rgf/utils.py:657: in fit
    sample_weight = self._get_sample_weight(sample_weight)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = RGFRegressor()
sample_weight = array([1., 0., 1., 1., 0., 1., 0., 0., 0., 1., 0., 1., 0., 1., 0., 0., 0.,
       1., 0., 1., 1., 0., 0., 0., 1., 1., 0., 1., 1., 0., 1., 1.])

    def _get_sample_weight(self, sample_weight):
        if sample_weight is not None:
            sample_weight = column_or_1d(sample_weight, warn=True)
            if (sample_weight <= 0).any():
>               raise ValueError("Sample weights must be positive.")
E               ValueError: Sample weights must be positive.
```

RGF doesn't support non-positive weights:
https://github.com/RGF-team/rgf/blob/8c05fd629ca478ac46b1ebed9ed4787bfa52e9c3/python-package/rgf/utils.py#L415-L420
https://github.com/RGF-team/rgf/blob/faf4b4ad6fe2d51b3ceb7384c7ac86b8071e2545/RGF/src/tet/AzTETrainer.hpp#L116-L117