### PR TITLE
fix numpy warning about np.float

### DIFF
--- a/python-package/rgf/utils.py
+++ b/python-package/rgf/utils.py
@@ -23,7 +23,7 @@ from sklearn.utils.multiclass import check_classification_targets
 from sklearn.utils.validation import check_array, check_consistent_length, check_X_y, column_or_1d
 
 
-FLOATS = (float, np.float, np.float16, np.float32, np.float64, np.double)
+FLOATS = (float, np.float16, np.float32, np.float64, np.double)
 INTS = (numbers.Integral, np.integer)
 NOT_FITTED_ERROR_DESC = "Estimator not fitted, call `fit` before exploiting the model."
 NOT_IMPLEMENTED_ERROR_DESC = "This method isn't implemented in base class."


### PR DESCRIPTION
Fix the following warning:
```
../../../../miniconda/envs/test-env/lib/python3.9/site-packages/rgf/utils.py:26
  /Users/runner/miniconda/envs/test-env/lib/python3.9/site-packages/rgf/utils.py:26: DeprecationWarning: `np.float` is a deprecated alias for the builtin `float`. To silence this warning, use `float` by itself. Doing this will not modify any behavior and is safe. If you specifically wanted the numpy scalar type, use `np.float64` here.
  Deprecated in NumPy 1.20; for more details and guidance: https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations
    FLOATS = (float, np.float, np.float16, np.float32, np.float64, np.double)
```