### PR TITLE
bump R version for Windows CI

### DIFF
--- a/.ci/python_tests_windows.ps1
+++ b/.ci/python_tests_windows.ps1
@@ -9,7 +9,7 @@ function Check-Output {
 
 $ProgressPreference = "SilentlyContinue"  # progress bar bug extremely slows down download speed
 $InstallerName = "$env:GITHUB_WORKSPACE\Miniconda3-latest-Windows-x86_64.exe"
-Invoke-WebRequest -Uri "https://repo.anaconda.com/miniconda/Miniconda3-latest-Windows-x86_64.exe" -OutFile $InstallerName
+Invoke-WebRequest -Uri "https://repo.anaconda.com/miniconda/Miniconda3-latest-Windows-x86_64.exe" -OutFile $InstallerName -MaximumRetryCount 3
 Start-Process -FilePath $InstallerName -ArgumentList "/InstallationType=JustMe /RegisterPython=0 /S /D=$env:CONDA_PATH" -Wait
 conda init powershell
 Invoke-Expression -Command "$env:USERPROFILE\Documents\WindowsPowerShell\profile.ps1"

--- a/.ci/r_tests_windows.ps1
+++ b/.ci/r_tests_windows.ps1
@@ -26,13 +26,13 @@ $env:_R_CHECK_CRAN_INCOMING_REMOTE_ = 0
 
 $R_VER = "4.0.4"
 $ProgressPreference = "SilentlyContinue"  # progress bar bug extremely slows down download speed
-Invoke-WebRequest -Uri https://cloud.r-project.org/bin/windows/base/old/$R_VER/R-$R_VER-win.exe -OutFile R-win.exe
+Invoke-WebRequest -Uri https://cloud.r-project.org/bin/windows/base/old/$R_VER/R-$R_VER-win.exe -OutFile R-win.exe -MaximumRetryCount 3
 Start-Process -FilePath R-win.exe -NoNewWindow -Wait -ArgumentList "/VERYSILENT /DIR=$env:R_LIB_PATH\R /COMPONENTS=main,x64" ; Check-Output $?
 
-Invoke-WebRequest -Uri https://cran.r-project.org/bin/windows/Rtools/rtools40-x86_64.exe -OutFile Rtools.exe
+Invoke-WebRequest -Uri https://cran.r-project.org/bin/windows/Rtools/rtools40-x86_64.exe -OutFile Rtools.exe -MaximumRetryCount 3
 Start-Process -FilePath Rtools.exe -NoNewWindow -Wait -ArgumentList "/VERYSILENT /SUPPRESSMSGBOXES /DIR=$env:R_LIB_PATH\Rtools" ; Check-Output $?
 
-Invoke-WebRequest -Uri https://miktex.org/download/win/miktexsetup-x64.zip -OutFile miktexsetup-x64.zip
+Invoke-WebRequest -Uri https://miktex.org/download/win/miktexsetup-x64.zip -OutFile miktexsetup-x64.zip -MaximumRetryCount 3
 Add-Type -AssemblyName System.IO.Compression.FileSystem
 [System.IO.Compression.ZipFile]::ExtractToDirectory("miktexsetup-x64.zip", "miktex")
 .\miktex\miktexsetup_standalone.exe --remote-package-repository="$env:CTAN_PACKAGE_ARCHIVE" --local-package-repository=.\miktex\download --package-set=essential --quiet download ; Check-Output $?

--- a/.ci/r_tests_windows.ps1
+++ b/.ci/r_tests_windows.ps1
@@ -24,7 +24,7 @@ Remove-Item C:\rtools40 -Force -Recurse -ErrorAction Ignore
 $env:_R_CHECK_CRAN_INCOMING_ = 0
 $env:_R_CHECK_CRAN_INCOMING_REMOTE_ = 0
 
-$R_VER = "4.0.3"
+$R_VER = "4.0.4"
 $ProgressPreference = "SilentlyContinue"  # progress bar bug extremely slows down download speed
 Invoke-WebRequest -Uri https://cloud.r-project.org/bin/windows/base/old/$R_VER/R-$R_VER-win.exe -OutFile R-win.exe
 Start-Process -FilePath R-win.exe -NoNewWindow -Wait -ArgumentList "/VERYSILENT /DIR=$env:R_LIB_PATH\R /COMPONENTS=main,x64" ; Check-Output $?


### PR DESCRIPTION
Run tests against the latest available R version.
For Linux and macOS it is done automatically with the help of targeting latest Docker image and using Homebrew respectively.

Also, retry downloading of files 3 times to prevent CI failure due to server temporary issues or poor network connection.