### PR TITLE
fix compatibility with roxygen2 > 7.0

### DIFF
--- a/.ci/r_tests.sh
+++ b/.ci/r_tests.sh
@@ -14,7 +14,7 @@ if [[ $OS_NAME == "macos-latest" ]]; then
   echo 'options(install.packages.check.source = "no")' >> .Rprofile
 else
   tlmgr --verify-repo=none update --self
-  tlmgr --verify-repo=none install ec
+  tlmgr --verify-repo=none install ec hyperref iftex infwarerr kvoptions pdftexcmds
 
   echo "Sys.setenv(RETICULATE_PYTHON = '$CONDA_PREFIX/bin/python')" >> .Rprofile
 fi

--- a/R-package/DESCRIPTION
+++ b/R-package/DESCRIPTION
@@ -21,5 +21,5 @@ Suggests:
     rmarkdown
 Encoding: UTF-8
 LazyData: true
-RoxygenNote: 7.0.2
+RoxygenNote: 7.1.1
 VignetteBuilder: knitr

--- a/R-package/man/FastRGF_Classifier.Rd
+++ b/R-package/man/FastRGF_Classifier.Rd
@@ -129,6 +129,7 @@ try({
 }
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-new"></a>}}
+\if{latex}{\out{\hypertarget{method-new}{}}}
 \subsection{Method \code{new()}}{
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{FastRGF_Classifier$new(
@@ -197,6 +198,7 @@ try({
 }
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-clone"></a>}}
+\if{latex}{\out{\hypertarget{method-clone}{}}}
 \subsection{Method \code{clone()}}{
 The objects of this class are cloneable with this method.
 \subsection{Usage}{

--- a/R-package/man/FastRGF_Regressor.Rd
+++ b/R-package/man/FastRGF_Regressor.Rd
@@ -121,6 +121,7 @@ try({
 }
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-new"></a>}}
+\if{latex}{\out{\hypertarget{method-new}{}}}
 \subsection{Method \code{new()}}{
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{FastRGF_Regressor$new(
@@ -183,6 +184,7 @@ try({
 }
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-clone"></a>}}
+\if{latex}{\out{\hypertarget{method-clone}{}}}
 \subsection{Method \code{clone()}}{
 The objects of this class are cloneable with this method.
 \subsection{Usage}{

--- a/R-package/man/Internal_class.Rd
+++ b/R-package/man/Internal_class.Rd
@@ -26,6 +26,7 @@ Internal R6 class for all secondary functions used in RGF and FastRGF
 }
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-fit"></a>}}
+\if{latex}{\out{\hypertarget{method-fit}{}}}
 \subsection{Method \code{fit()}}{
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{Internal_class$fit(x, y, sample_weight = NULL)}\if{html}{\out{</div>}}
@@ -34,6 +35,7 @@ Internal R6 class for all secondary functions used in RGF and FastRGF
 }
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-predict"></a>}}
+\if{latex}{\out{\hypertarget{method-predict}{}}}
 \subsection{Method \code{predict()}}{
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{Internal_class$predict(x)}\if{html}{\out{</div>}}
@@ -42,6 +44,7 @@ Internal R6 class for all secondary functions used in RGF and FastRGF
 }
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-predict_proba"></a>}}
+\if{latex}{\out{\hypertarget{method-predict_proba}{}}}
 \subsection{Method \code{predict_proba()}}{
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{Internal_class$predict_proba(x)}\if{html}{\out{</div>}}
@@ -50,6 +53,7 @@ Internal R6 class for all secondary functions used in RGF and FastRGF
 }
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-cleanup"></a>}}
+\if{latex}{\out{\hypertarget{method-cleanup}{}}}
 \subsection{Method \code{cleanup()}}{
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{Internal_class$cleanup()}\if{html}{\out{</div>}}
@@ -58,6 +62,7 @@ Internal R6 class for all secondary functions used in RGF and FastRGF
 }
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-get_params"></a>}}
+\if{latex}{\out{\hypertarget{method-get_params}{}}}
 \subsection{Method \code{get_params()}}{
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{Internal_class$get_params(deep = TRUE)}\if{html}{\out{</div>}}
@@ -66,6 +71,7 @@ Internal R6 class for all secondary functions used in RGF and FastRGF
 }
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-score"></a>}}
+\if{latex}{\out{\hypertarget{method-score}{}}}
 \subsection{Method \code{score()}}{
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{Internal_class$score(x, y, sample_weight = NULL)}\if{html}{\out{</div>}}
@@ -74,6 +80,7 @@ Internal R6 class for all secondary functions used in RGF and FastRGF
 }
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-feature_importances"></a>}}
+\if{latex}{\out{\hypertarget{method-feature_importances}{}}}
 \subsection{Method \code{feature_importances()}}{
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{Internal_class$feature_importances()}\if{html}{\out{</div>}}
@@ -82,6 +89,7 @@ Internal R6 class for all secondary functions used in RGF and FastRGF
 }
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-dump_model"></a>}}
+\if{latex}{\out{\hypertarget{method-dump_model}{}}}
 \subsection{Method \code{dump_model()}}{
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{Internal_class$dump_model()}\if{html}{\out{</div>}}
@@ -90,6 +98,7 @@ Internal R6 class for all secondary functions used in RGF and FastRGF
 }
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-save_model"></a>}}
+\if{latex}{\out{\hypertarget{method-save_model}{}}}
 \subsection{Method \code{save_model()}}{
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{Internal_class$save_model(filename)}\if{html}{\out{</div>}}
@@ -98,6 +107,7 @@ Internal R6 class for all secondary functions used in RGF and FastRGF
 }
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-clone"></a>}}
+\if{latex}{\out{\hypertarget{method-clone}{}}}
 \subsection{Method \code{clone()}}{
 The objects of this class are cloneable with this method.
 \subsection{Usage}{

--- a/R-package/man/RGF_Classifier.Rd
+++ b/R-package/man/RGF_Classifier.Rd
@@ -143,6 +143,7 @@ try({
 }
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-new"></a>}}
+\if{latex}{\out{\hypertarget{method-new}{}}}
 \subsection{Method \code{new()}}{
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{RGF_Classifier$new(
@@ -211,6 +212,7 @@ try({
 }
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-clone"></a>}}
+\if{latex}{\out{\hypertarget{method-clone}{}}}
 \subsection{Method \code{clone()}}{
 The objects of this class are cloneable with this method.
 \subsection{Usage}{

--- a/R-package/man/RGF_Regressor.Rd
+++ b/R-package/man/RGF_Regressor.Rd
@@ -135,6 +135,7 @@ try({
 }
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-new"></a>}}
+\if{latex}{\out{\hypertarget{method-new}{}}}
 \subsection{Method \code{new()}}{
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{RGF_Regressor$new(
@@ -197,6 +198,7 @@ try({
 }
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-clone"></a>}}
+\if{latex}{\out{\hypertarget{method-clone}{}}}
 \subsection{Method \code{clone()}}{
 The objects of this class are cloneable with this method.
 \subsection{Usage}{


### PR DESCRIPTION
Unfortunately, installation of `texlive-latex-extra` didn't help (refer to https://github.com/microsoft/LightGBM/pull/4084).
But looks like I've found minimal bundle of TeX packages required to be compatible with `roxygen2` > 7.0. The main one was `hyperref`, absence of which caused CRAN checks to fail with `! Undefined control sequence. l.152 \hypertarget` error.