### PR TITLE
update to CRAN version 1.0.8

### DIFF
--- a/R-package/DESCRIPTION
+++ b/R-package/DESCRIPTION
@@ -1,10 +1,9 @@
 Package: RGF
 Type: Package
 Title: Regularized Greedy Forest
-Version: 1.0.7
-Date: 2021-03-17
-Authors@R: c( person("Lampros", "Mouselimis", email = "mouselimislampros@gmail.com", role = c("aut", "cre")), person("Ryosuke", "Fukatani", role = "cph", comment = "Author of the python wrapper of the 'Regularized Greedy Forest' machine learning algorithm"), person("Nikita", "Titov", role = "cph", comment = "Author of the python wrapper of the 'Regularized Greedy Forest' machine learning algorithm"), person("Tong", "Zhang", role = "cph", comment = "Author of the 'Regularized Greedy Forest' and of the Multi-core implementation of Regularized Greedy Forest machine learning algorithm"), person("Rie", "Johnson", role = "cph", comment = "Author of the 'Regularized Greedy Forest' machine learning algorithm") )
-Maintainer: Lampros Mouselimis <mouselimislampros@gmail.com>
+Version: 1.0.8
+Date: 2021-05-07
+Authors@R: c( person("Lampros", "Mouselimis", email = "mouselimislampros@gmail.com", role = c("aut", "cre"), comment = c(ORCID = "https://orcid.org/0000-0002-8024-1546")), person("Ryosuke", "Fukatani", role = "cph", comment = "Author of the python wrapper of the 'Regularized Greedy Forest' machine learning algorithm"), person("Nikita", "Titov", role = "cph", comment = "Author of the python wrapper of the 'Regularized Greedy Forest' machine learning algorithm"), person("Tong", "Zhang", role = "cph", comment = "Author of the 'Regularized Greedy Forest' and of the Multi-core implementation of Regularized Greedy Forest machine learning algorithm"), person("Rie", "Johnson", role = "cph", comment = "Author of the 'Regularized Greedy Forest' machine learning algorithm") )
 BugReports: https://github.com/RGF-team/rgf/issues
 URL: https://github.com/RGF-team/rgf/tree/master/R-package
 Description: Regularized Greedy Forest wrapper of the 'Regularized Greedy Forest' <https://github.com/RGF-team/rgf/tree/master/python-package> 'python' package, which also includes a Multi-core implementation (FastRGF) <https://github.com/RGF-team/rgf/tree/master/FastRGF>.
@@ -13,13 +12,14 @@ SystemRequirements: Python (>= 3.6), rgf_python, scikit-learn (>= 0.18.0), scipy
 Depends:
     R(>= 3.2.0)
 Imports:
-    reticulate, R6, Matrix
+    reticulate, 
+    R6, 
+    Matrix
 Suggests:
     testthat,
     covr,
     knitr,
     rmarkdown
 Encoding: UTF-8
-LazyData: true
 RoxygenNote: 7.1.1
 VignetteBuilder: knitr

--- a/R-package/NEWS.md
+++ b/R-package/NEWS.md
@@ -1,3 +1,12 @@
+## RGF 1.0.8
+* We've modified the DESCRIPTION file by adding the 'Orcid' Number for the person 'Lampros Mouselimis'
+* We've removed the 'maintainer' in the DESCRIPTION because this field is created automatically
+* We've removed the 'LazyData' in the DESCRIPTION file that gave a NOTE on the CRAN checks
+* We've converted all 'reticulate::py_available(initialize = TRUE)' to 'reticulate::py_available(initialize = FALSE)' otherwise it would give a NOTE on the CRAN tests for the Windows Operating System
+* We've removed all comments from the 'package.R' file
+* We've added the 'inst' folder and the 'CITATION' file to cite the software and the original articles / software
+
+
 ## RGF 1.0.7
 * We've modified the *package.R* file so that messages are printed to the console whenever Python or any of the required modules is not available. Moreover, for the R-package testing the conda environment parameter is adjusted ( this applies to the RGF-team Github repository and not to the CRAN package directly )
 * We've modified the *.appveyor.yml* file to return the *artifacts* in order to observe if tests ran successfully ( this applies to the RGF-team Github repository and not to the CRAN package directly )

--- a/R-package/R/FastRGF_Classifier.R
+++ b/R-package/R/FastRGF_Classifier.R
@@ -94,7 +94,7 @@
 #' @examples
 #'
 #' try({
-#'     if (reticulate::py_available(initialize = TRUE)) {
+#'     if (reticulate::py_available(initialize = FALSE)) {
 #'         if (reticulate::py_module_available("rgf.sklearn")) {
 #'
 #'             library(RGF)

--- a/R-package/R/FastRGF_Regressor.R
+++ b/R-package/R/FastRGF_Regressor.R
@@ -84,7 +84,7 @@
 #' @examples
 #'
 #' try({
-#'     if (reticulate::py_available(initialize = TRUE)) {
+#'     if (reticulate::py_available(initialize = FALSE)) {
 #'         if (reticulate::py_module_available("rgf.sklearn")) {
 #'
 #'             library(RGF)

--- a/R-package/R/RGF_Classifier.R
+++ b/R-package/R/RGF_Classifier.R
@@ -110,7 +110,7 @@
 #' @examples
 #'
 #' try({
-#'     if (reticulate::py_available(initialize = TRUE)) {
+#'     if (reticulate::py_available(initialize = FALSE)) {
 #'         if (reticulate::py_module_available("rgf.sklearn")) {
 #'
 #'             library(RGF)

--- a/R-package/R/RGF_Regressor.R
+++ b/R-package/R/RGF_Regressor.R
@@ -100,7 +100,7 @@
 #' @examples
 #'
 #' try({
-#'     if (reticulate::py_available(initialize = TRUE)) {
+#'     if (reticulate::py_available(initialize = FALSE)) {
 #'         if (reticulate::py_module_available("rgf.sklearn")) {
 #'
 #'             library(RGF)

--- a/R-package/R/TO_scipy_sparse.R
+++ b/R-package/R/TO_scipy_sparse.R
@@ -14,7 +14,7 @@
 #' @examples
 #'
 #' try({
-#'     if (reticulate::py_available(initialize = TRUE)) {
+#'     if (reticulate::py_available(initialize = FALSE)) {
 #'         if (reticulate::py_module_available("scipy")) {
 #'
 #'             if (Sys.info()["sysname"] != 'Darwin') {

--- a/R-package/R/mat_2scipy_sparse.R
+++ b/R-package/R/mat_2scipy_sparse.R
@@ -10,7 +10,7 @@
 #' @examples
 #'
 #' try({
-#'     if (reticulate::py_available(initialize = TRUE)) {
+#'     if (reticulate::py_available(initialize = FALSE)) {
 #'         if (reticulate::py_module_available("scipy")) {
 #'
 #'             library(RGF)

--- a/R-package/R/package.R
+++ b/R-package/R/package.R
@@ -8,57 +8,21 @@ RGF_mod <- NULL; RGF_utils <- NULL; SCP <- NULL;
 
 .onLoad <- function(libname, pkgname) {
 
-  #---------------------------------------------------------------------------  keep these lines for debugging
-  # print(reticulate::py_discover_config())               # it throws an error
-  #
-  # see the following issues / references:
-  #  - https://github.com/rstudio/reticulate/issues/394
-  #  - https://github.com/rstudio/reticulate/issues/292#issuecomment-399208184
-  #  - https://github.com/rstudio/reticulate/issues/568#issuecomment-517926879
-  #  - https://rdrr.io/github/kojikoji/ptcomp/src/R/zzz.R
-  #  - http://r-pkgs.had.co.nz/r.html                       # usage of .onLoad
-  #
-  # available conda environments:
-  # print(reticulate::conda_list(conda = "auto"))
-  #               name                                                  python
-  # 1  Miniconda36-x64                         C:\\Miniconda36-x64\\python.exe
-  # 2 test-environment C:\\Miniconda36-x64\\envs\\test-environment\\python.exe
-  # force reticulate to use the desired conda environment:
-  # reticulate::use_condaenv('test-environment', required = TRUE)
-  #---------------------------------------------------------------------------
-
-  try({       # I added the try() functions in version 1.0.7 because I received a similar warning as mentioned in: [ https://github.com/rstudio/reticulate/issues/730#issuecomment-594365528 ] and [ https://github.com/rstudio/reticulate/issues/814 ]
-    RGF_mod <<- reticulate::import("rgf.sklearn", delay_load = TRUE)
-  }, silent = TRUE)
-
   try({
-    RGF_utils <<- reticulate::import("rgf.utils", delay_load = TRUE)
-  }, silent = TRUE)
+    if (reticulate::py_available(initialize = FALSE)) {
 
-  try({
-    SCP <<- reticulate::import("scipy", delay_load = TRUE, convert = FALSE)
-  }, silent = TRUE)
+      try({
+        RGF_mod <<- reticulate::import("rgf.sklearn", delay_load = TRUE)
+      }, silent = TRUE)
 
-  # #................................................................................. keep this as a reference, however it gives a warning on CRAN because it tries to initialize python
-  # try({
-  #   if (reticulate::py_module_available("rgf.sklearn")) {
-  #     RGF_mod <<- reticulate::import("rgf.sklearn", delay_load = TRUE)
-  #   }
-  #   # else {
-  #   #   packageStartupMessage("The 'rgf.sklearn' module is not available!")          # keep these lines for debugging
-  #   # }
-  #   if (reticulate::py_module_available("rgf.utils")) {
-  #     RGF_utils <<- reticulate::import("rgf.utils", delay_load = TRUE)
-  #   }
-  #   # else {
-  #   #   packageStartupMessage("The 'rgf.utils' module is not available!")
-  #   # }
-  #   if (reticulate::py_module_available("scipy")) {
-  #     SCP <<- reticulate::import("scipy", delay_load = TRUE, convert = FALSE)
-  #   }
-  #   # else {
-  #   #   packageStartupMessage("The 'scipy' package is not available!")
-  #   # }
-  # }, silent = TRUE)
-  # #.................................................................................
+      try({
+        RGF_utils <<- reticulate::import("rgf.utils", delay_load = TRUE)
+      }, silent = TRUE)
+
+      try({
+        SCP <<- reticulate::import("scipy", delay_load = TRUE, convert = FALSE)
+      }, silent = TRUE)
+
+    }
+  }, silent=TRUE)
 }

--- a/R-package/R/package.R
+++ b/R-package/R/package.R
@@ -9,7 +9,7 @@ RGF_mod <- NULL; RGF_utils <- NULL; SCP <- NULL;
 .onLoad <- function(libname, pkgname) {
 
   try({
-    if (reticulate::py_available(initialize = FALSE)) {
+    if (reticulate::py_available(initialize = TRUE)) {
 
       try({
         RGF_mod <<- reticulate::import("rgf.sklearn", delay_load = TRUE)

--- a/R-package/README.md
+++ b/R-package/README.md
@@ -564,19 +564,8 @@ Use the following link to report bugs/issues,
 
 ### **Citation:**
 
-If you use the code of this repository in your paper or research please cite both **RGF** and the **original articles / software** [https://cran.r-project.org/web/packages/RGF/citation.html](https://cran.r-project.org/web/packages/RGF/citation.html):
+If you use the code of this repository in your paper or research please cite both **RGF** and the **original articles / software**:
 
-<br>
-
-```R
-@Manual{,
-  title = {{RGF}: Regularized Greedy Forest},
-  author = {Lampros Mouselimis and Ryosuke Fukatani and Nikita Titov
-    and Tong Zhang and Rie Johnson},
-  year = {2021},
-  note = {R package version 1.0.8},
-  url = {https://CRAN.R-project.org/package=RGF},
-}
-```
+* [https://cran.r-project.org/web/packages/RGF/citation.html](https://cran.r-project.org/web/packages/RGF/citation.html)
 
 <br>

--- a/R-package/README.md
+++ b/R-package/README.md
@@ -561,3 +561,22 @@ Use the following link to report bugs/issues,
 
 [https://github.com/RGF-team/rgf/issues](https://github.com/RGF-team/rgf/issues)
 <br>
+
+### **Citation:**
+
+If you use the code of this repository in your paper or research please cite both **RGF** and the **original articles / software** [https://cran.r-project.org/web/packages/RGF/citation.html](https://cran.r-project.org/web/packages/RGF/citation.html):
+
+<br>
+
+```R
+@Manual{,
+  title = {{RGF}: Regularized Greedy Forest},
+  author = {Lampros Mouselimis and Ryosuke Fukatani and Nikita Titov
+    and Tong Zhang and Rie Johnson},
+  year = {2021},
+  note = {R package version 1.0.8},
+  url = {https://CRAN.R-project.org/package=RGF},
+}
+```
+
+<br>

--- a/R-package/inst/CITATION
+++ b/R-package/inst/CITATION
@@ -1,0 +1,41 @@
+citHeader("Please cite both the package and the original articles / software in your publications:")
+
+year <- sub("-.*", "", meta$Date)
+note <- sprintf("R package version %s", meta$Version)
+
+bibentry(
+  bibtype = "Manual",
+  title   = "{RGF}: Regularized Greedy Forest",
+  author  = c(person("Lampros", "Mouselimis"), person("Ryosuke", "Fukatani"), person("Nikita", "Titov"), person("Tong", "Zhang"), person("Rie", "Johnson")),
+  year    = year,
+  note    = note,
+  url     = "https://CRAN.R-project.org/package=RGF"
+)
+
+bibentry(
+  bibtype = "Manual",
+  title   = "{rgf_python}: The wrapper of machine learning algorithm Regularized Greedy Forest (RGF) for Python",
+  author  = c(person("Ryosuke", "Fukatani"), person("Nikita", "Titov"), person("Tong", "Zhang"), person("Rie", "Johnson")),
+  year    = 2021,
+  url     = "https://pypi.org/project/rgf-python/"
+)
+
+bibentry(
+  bibtype  = "Article",
+  title    = "Learning Nonlinear Functions Using Regularized Greedy Forest",
+  author   = c(as.person("Rie Johnson"), as.person("Tong Zhang")),
+  journal  = "IEEE Transactions on Pattern Analysis and Machine Intelligence",
+  year     = "2014",
+  volume   = "36",
+  pages    = "942--954",
+  doi      = "10.1109/TPAMI.2013.159"
+)
+
+bibentry(
+  bibtype  = "Article",
+  title    = "Learning Nonlinear Functions Using Regularized Greedy Forest",
+  author   = c(as.person("Rie Johnson"), as.person("Tong Zhang")),
+  journal  = "arXiv.org, stat.ML",
+  year     = "2011",
+  note     = "arXiv:1109.0887"
+)

--- a/R-package/inst/CITATION
+++ b/R-package/inst/CITATION
@@ -16,7 +16,7 @@ bibentry(
   bibtype = "Manual",
   title   = "{rgf_python}: The wrapper of machine learning algorithm Regularized Greedy Forest (RGF) for Python",
   author  = c(person("Ryosuke", "Fukatani"), person("Nikita", "Titov"), person("Tong", "Zhang"), person("Rie", "Johnson")),
-  year    = 2021,
+  year    = year,
   url     = "https://pypi.org/project/rgf-python/"
 )
 

--- a/R-package/man/FastRGF_Classifier.Rd
+++ b/R-package/man/FastRGF_Classifier.Rd
@@ -80,7 +80,7 @@ the \emph{score} function returns the mean accuracy on the given test data and l
 \examples{
 
 try({
-    if (reticulate::py_available(initialize = TRUE)) {
+    if (reticulate::py_available(initialize = FALSE)) {
         if (reticulate::py_module_available("rgf.sklearn")) {
 
             library(RGF)

--- a/R-package/man/FastRGF_Regressor.Rd
+++ b/R-package/man/FastRGF_Regressor.Rd
@@ -72,7 +72,7 @@ the \emph{score} function returns the coefficient of determination ( R^2 ) for t
 \examples{
 
 try({
-    if (reticulate::py_available(initialize = TRUE)) {
+    if (reticulate::py_available(initialize = FALSE)) {
         if (reticulate::py_module_available("rgf.sklearn")) {
 
             library(RGF)

--- a/R-package/man/RGF_Classifier.Rd
+++ b/R-package/man/RGF_Classifier.Rd
@@ -94,7 +94,7 @@ the \emph{save_model} function saves a model to a file from which training can d
 \examples{
 
 try({
-    if (reticulate::py_available(initialize = TRUE)) {
+    if (reticulate::py_available(initialize = FALSE)) {
         if (reticulate::py_module_available("rgf.sklearn")) {
 
             library(RGF)

--- a/R-package/man/RGF_Regressor.Rd
+++ b/R-package/man/RGF_Regressor.Rd
@@ -86,7 +86,7 @@ the \emph{save_model} function saves a model to a file from which training can d
 \examples{
 
 try({
-    if (reticulate::py_available(initialize = TRUE)) {
+    if (reticulate::py_available(initialize = FALSE)) {
         if (reticulate::py_module_available("rgf.sklearn")) {
 
             library(RGF)

--- a/R-package/man/TO_scipy_sparse.Rd
+++ b/R-package/man/TO_scipy_sparse.Rd
@@ -20,7 +20,7 @@ The \emph{dgCMatrix} class is a class of sparse numeric matrices in the compress
 \examples{
 
 try({
-    if (reticulate::py_available(initialize = TRUE)) {
+    if (reticulate::py_available(initialize = FALSE)) {
         if (reticulate::py_module_available("scipy")) {
 
             if (Sys.info()["sysname"] != 'Darwin') {

--- a/R-package/man/mat_2scipy_sparse.Rd
+++ b/R-package/man/mat_2scipy_sparse.Rd
@@ -20,7 +20,7 @@ This function allows the user to convert an R matrix to a scipy sparse matrix. T
 \examples{
 
 try({
-    if (reticulate::py_available(initialize = TRUE)) {
+    if (reticulate::py_available(initialize = FALSE)) {
         if (reticulate::py_module_available("scipy")) {
 
             library(RGF)

--- a/R-package/tests/testthat/helper-skip.R
+++ b/R-package/tests/testthat/helper-skip.R
@@ -4,7 +4,7 @@
 #.......................................
 
 skip_test_if_no_python <- function() {
-  if (!reticulate::py_available(initialize = TRUE))
+  if (!reticulate::py_available(initialize = FALSE))
     testthat::skip("Python bindings not available for testing")
 }
 

--- a/R-package/tests/testthat/test-RGF_package.R
+++ b/R-package/tests/testthat/test-RGF_package.R
@@ -14,7 +14,6 @@ testthat::test_that("the methods of the 'RGF_Regressor' class return the correct
   #............................................................................................................
 
   skip_test_if_no_python()
-
   skip_test_if_no_module("rgf.sklearn")
 
   init_regr = RGF_Regressor$new(max_leaf = 50, sl2 = 0.1, n_iter = 10)
@@ -44,7 +43,6 @@ testthat::test_that("the methods of the 'RGF_Regressor' class return the correct
 testthat::test_that("the methods of the 'RGF_Classifier' class return the correct output (binary classification)", {
 
   skip_test_if_no_python()
-
   skip_test_if_no_module("rgf.sklearn")
 
   init_class = RGF_Classifier$new(max_leaf = 50, sl2 = 0.1, n_iter = 10)
@@ -73,7 +71,6 @@ testthat::test_that("the methods of the 'RGF_Classifier' class return the correc
 testthat::test_that("the methods of the 'RGF_Classifier' class return the correct output (multiclass classification)", {
 
   skip_test_if_no_python()
-
   skip_test_if_no_module("rgf.sklearn")
 
   init_class = RGF_Classifier$new(max_leaf = 50, sl2 = 0.1, n_iter = 10)
@@ -107,7 +104,6 @@ testthat::test_that("the methods of the 'RGF_Classifier' class return the correc
 testthat::test_that("the methods of the 'FastRGF_Regressor' class return the correct output", {
 
   skip_test_if_no_python()
-
   skip_test_if_no_module("rgf.sklearn")
 
   init_regr = FastRGF_Regressor$new(n_estimators = 50, max_bin = 65000)
@@ -142,7 +138,6 @@ testthat::test_that("the methods of the 'FastRGF_Regressor' class return the cor
 testthat::test_that("the methods of the 'FastRGF_Classifier' class return the correct output (binary classification)", {
 
   skip_test_if_no_python()
-
   skip_test_if_no_module("rgf.sklearn")
 
   init_class = FastRGF_Classifier$new(n_estimators = 50, max_bin = 65000)
@@ -172,7 +167,6 @@ testthat::test_that("the methods of the 'FastRGF_Classifier' class return the co
 testthat::test_that("the methods of the 'FastRGF_Classifier' class return the correct output (multiclass classification)", {
 
   skip_test_if_no_python()
-
   skip_test_if_no_module("rgf.sklearn")
 
   init_class = FastRGF_Classifier$new(n_estimators = 50, max_bin = 65000)
@@ -208,7 +202,6 @@ testthat::test_that("the methods of the 'FastRGF_Classifier' class return the co
 testthat::test_that("the 'mat_2scipy_sparse' returns an error in case that the data is not inheriting matrix class", {
 
   skip_test_if_no_python()
-
   skip_test_if_no_module("scipy")
 
   x_rgf_invalid = as.data.frame(x_rgf)
@@ -220,7 +213,6 @@ testthat::test_that("the 'mat_2scipy_sparse' returns an error in case that the d
 testthat::test_that("the 'mat_2scipy_sparse' returns an error in case that the 'format' parameter is invalid", {
 
   skip_test_if_no_python()
-
   skip_test_if_no_module("scipy")
 
   testthat::expect_error( mat_2scipy_sparse(x_rgf, format = 'invalid') )
@@ -230,7 +222,6 @@ testthat::test_that("the 'mat_2scipy_sparse' returns an error in case that the '
 testthat::test_that("the 'mat_2scipy_sparse' returns a scipy CSR sparse matrix", {
 
   skip_test_if_no_python()
-
   skip_test_if_no_module("scipy")
 
   res = mat_2scipy_sparse(x_rgf, format = 'sparse_row_matrix')
@@ -244,7 +235,6 @@ testthat::test_that("the 'mat_2scipy_sparse' returns a scipy CSR sparse matrix",
 testthat::test_that("the 'mat_2scipy_sparse' returns a scipy CSC sparse matrix", {
 
   skip_test_if_no_python()
-
   skip_test_if_no_module("scipy")
 
   res = mat_2scipy_sparse(x_rgf, format = 'sparse_column_matrix')
@@ -269,7 +259,6 @@ if (Sys.info()["sysname"] != 'Darwin') {
   testthat::test_that("the 'TO_scipy_sparse' returns an error in case that the input object is not of type 'dgCMatrix' or 'dgRMatrix'", {
 
     skip_test_if_no_python()
-
     skip_test_if_no_module("scipy")
 
     mt = matrix(runif(20), nrow = 5, ncol = 4)
@@ -281,7 +270,6 @@ if (Sys.info()["sysname"] != 'Darwin') {
   testthat::test_that("the 'TO_scipy_sparse' returns the correct output for dgCMatrix", {
 
     skip_test_if_no_python()
-
     skip_test_if_no_module("scipy")
 
     data = c(1, 0, 2, 0, 0, 3, 4, 5, 6)
@@ -303,7 +291,6 @@ if (Sys.info()["sysname"] != 'Darwin') {
   testthat::test_that("the 'TO_scipy_sparse' returns the correct output for dgRMatrix", {
 
     skip_test_if_no_python()
-
     skip_test_if_no_module("scipy")
 
     data = c(1, 0, 2, 0, 0, 3, 4, 5, 6)
@@ -328,7 +315,6 @@ if (Sys.info()["sysname"] != 'Darwin') {
   testthat::test_that("the RGF_Regressor works with sparse (scipy) matrices", {
 
     skip_test_if_no_python()
-
     skip_test_if_no_module(c("rgf.sklearn", 'scipy'))
 
     set.seed(1)
@@ -370,7 +356,6 @@ if (Sys.info()["sysname"] != 'Darwin') {
 testthat::test_that("the feature importances of the 'RGF_Regressor' class works as expected", {
 
   skip_test_if_no_python()
-
   skip_test_if_no_module("rgf.sklearn")
 
   init_regr = RGF_Regressor$new(max_leaf = 50, sl2 = 0.1, n_iter = 10)
@@ -390,7 +375,6 @@ testthat::test_that("the feature importances of the 'RGF_Regressor' class works 
 testthat::test_that("the 'dump_model' method returns the correct output (Dumps the forest information to the R session -- works ONLY for RGF and NOT for FastRGF)", {
 
   skip_test_if_no_python()
-
   skip_test_if_no_module("rgf.sklearn")
 
   init_class = RGF_Classifier$new(max_leaf = 50, sl2 = 0.1, n_iter = 10)
@@ -442,7 +426,6 @@ testthat::test_that("the 'dump_model' method returns the correct output (Dumps t
 testthat::test_that("the 'save_model' method returns the correct output -- works ONLY for RGF and NOT for FastRGF", {
 
   skip_test_if_no_python()
-
   skip_test_if_no_module("rgf.sklearn")
 
   init_class = RGF_Classifier$new(max_leaf = 50, sl2 = 0.1, n_iter = 10)
@@ -481,7 +464,6 @@ testthat::test_that("the 'save_model' method returns the correct output -- works
 testthat::test_that("the 'cleanup' method (ESTIMATOR specific) works as expected for both RGF and FastRGF (checking of the size of the temporary directory before and after the '$fit' method)", {
 
   skip_test_if_no_python()
-
   skip_test_if_no_module("rgf.sklearn")
 
   #--------------------------------------------------------------------------------
@@ -531,7 +513,6 @@ testthat::test_that("the 'cleanup' method (ESTIMATOR specific) works as expected
 testthat::test_that("the 'cleanup' method (APPLIES TO ALL ESTIMATORS) works as expected for both RGF and FastRGF (checking of the size of the temporary directory before and after the '$fit' method)", {
 
   skip_test_if_no_python()
-
   skip_test_if_no_module("rgf.sklearn")
 
   #--------------------------------------------------------------------------------


### PR DESCRIPTION
I've updated the R package to CRAN version 1.0.8 and,

* I've modified the DESCRIPTION file by adding my 'Orcid' Number
* I've removed the 'maintainer' in the DESCRIPTION because this field is created automatically
* I've removed the 'LazyData' in the DESCRIPTION file that gave a NOTE on the CRAN checks
* I've converted all 'reticulate::py_available(initialize = TRUE)' to 'reticulate::py_available(initialize = FALSE)' otherwise it would give a NOTE on the CRAN tests for the Windows Operating System
* I've removed all comments from the 'package.R' file
* I've added the 'inst' folder and the 'CITATION' file to cite the software and the original articles / software

I am aware of the [discussion](https://github.com/RGF-team/rgf/pull/338#issuecomment-822874287) in #338 therefore I've set as Reviewer only @StrikerRUS. In any other case, just tell me and I'll add Reviewers. Thanks.