### PR TITLE
Support gcc-11

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ on:
     - master
 
 env:
-  GCC_VER_MACOS: '10'
+  GCC_VER_MACOS: '11'
   GCC_VER_LINUX: '5'
 jobs:
   test:

--- a/RGF/README.md
+++ b/RGF/README.md
@@ -11,7 +11,7 @@ Please see the file [`CHANGES.md`](./CHANGES.md) for the changelog of RGF.
 # 0.1 Acknowledgements
 
   We thank **Dave Slate** for suggesting a solution to the issue of file size
-  restriction above.
+  restriction.
 
 ************************************************************************
 
@@ -79,8 +79,6 @@ Otherwise, your executable can be anywhere you like.
 
 The easiest way. Just download the precompiled file `rgf.exe`
 from the latest [GitHub release](https://github.com/RGF-team/rgf/releases).
-
-For 32-bit Windows download `rgf32.exe` file and rename it to `rgf.exe`.
 
 ### 3.1.2. Visual Studio (Using the Provided Solution File)
 

--- a/python-package/Readme.rst
+++ b/python-package/Readme.rst
@@ -75,6 +75,8 @@ or from `GitHub <https://github.com/RGF-team/rgf/python-package>`__:
     cd rgf/python-package
     python setup.py install
 
+MacOS users, **rgf\_python** after the ``3.10.0`` version is built with **g++-11** and cannot be launched on systems with **g++-10** and earlier. You should update your **g++** compiler if you don't want to build from sources or install **rgf\_python** ``3.10.0`` from PyPI which is the last version built with **g++-10**.
+
 MacOS users, **rgf\_python** after the ``3.8.0`` version is built with **g++-10** and cannot be launched on systems with **g++-9** and earlier. You should update your **g++** compiler if you don't want to build from sources or install **rgf\_python** ``3.8.0`` from PyPI which is the last version built with **g++-9**.
 
 MacOS users, **rgf\_python** after the ``3.5.0`` version is built with **g++-9** and cannot be launched on systems with **g++-8** and earlier. You should update your **g++** compiler if you don't want to build from sources or install **rgf\_python** ``3.5.0`` from PyPI which is the last version built with **g++-8**.

--- a/python-package/setup.py
+++ b/python-package/setup.py
@@ -249,7 +249,7 @@ def compile_fastrgf():
         if tmp_result or system() in ('Windows', 'Microsoft'):
             return tmp_result
 
-        for version in range(5, 11):
+        for version in range(5, 12):
             try:
                 subprocess.check_output(('g++-' + str(version), '--version'))
                 return True


### PR DESCRIPTION
Also, remove a line in README about `rgf32.exe`. We are no longer providing it.