### PR TITLE
update R-package-version

### DIFF
--- a/R-package/DESCRIPTION
+++ b/R-package/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: RGF
 Type: Package
 Title: Regularized Greedy Forest
-Version: 1.0.8
-Date: 2021-05-07
+Version: 1.0.9
+Date: 2021-09-11
 Authors@R: c( person("Lampros", "Mouselimis", email = "mouselimislampros@gmail.com", role = c("aut", "cre"), comment = c(ORCID = "https://orcid.org/0000-0002-8024-1546")), person("Ryosuke", "Fukatani", role = "cph", comment = "Author of the python wrapper of the 'Regularized Greedy Forest' machine learning algorithm"), person("Nikita", "Titov", role = "cph", comment = "Author of the python wrapper of the 'Regularized Greedy Forest' machine learning algorithm"), person("Tong", "Zhang", role = "cph", comment = "Author of the 'Regularized Greedy Forest' and of the Multi-core implementation of Regularized Greedy Forest machine learning algorithm"), person("Rie", "Johnson", role = "cph", comment = "Author of the 'Regularized Greedy Forest' machine learning algorithm") )
 BugReports: https://github.com/RGF-team/rgf/issues
 URL: https://github.com/RGF-team/rgf/tree/master/R-package

--- a/R-package/NEWS.md
+++ b/R-package/NEWS.md
@@ -1,3 +1,7 @@
+## RGF 1.0.9
+* We've added a 'packageStartupMessage' informing the user in case of the error 'attempt to apply non-function' that he/she has to use the 'reticulate::py_config()' before loading the package (in a new R session)
+
+
 ## RGF 1.0.8
 * We've modified the DESCRIPTION file by adding the 'Orcid' Number for the person 'Lampros Mouselimis'
 * We've removed the 'maintainer' in the DESCRIPTION because this field is created automatically

--- a/R-package/R/package.R
+++ b/R-package/R/package.R
@@ -26,3 +26,8 @@ RGF_mod <- NULL; RGF_utils <- NULL; SCP <- NULL;
     }
   }, silent=TRUE)
 }
+
+
+.onAttach <- function(libname, pkgname) {
+  packageStartupMessage("If the 'RGF' package gives the following error: 'attempt to apply non-function' then make sure to open a new R session and run 'reticulate::py_config()' before loading the package!")
+}

--- a/R-package/README.md
+++ b/R-package/README.md
@@ -339,7 +339,7 @@ gcc --version
 
 <br>
 
-Normally MinGW is installed in the **C:\\** directory. So, first delete the folder **C:\\MinGW** (if it already exists), and then remove the environment variable from (Control Panel >> System and Security >> System >> Advanced system settings >> Environment variables >> System variables >> Path >> Edit) which usually is **C:\\MinGW\\bin**. Then download the most recent version of [MinGW](http://mingw-w64.org/doku.php), and especially the **mingw-get-setup.exe** which is an *automated GUI installer assistant*. After the new version is installed successfully, update the environment variable by adding **C:\\MinGW\\bin** in (Control Panel >> System and Security >> System >> Advanced system settings >> Environment variables >> System variables >> Path >> Edit). Then open a new command prompt (console) and type, 
+Normally MinGW is installed in the **C:\\** directory. So, first delete the folder **C:\\MinGW** (if it already exists), and then remove the environment variable from (Control Panel >> System and Security >> System >> Advanced system settings >> Environment variables >> System variables >> Path >> Edit) which usually is **C:\\MinGW\\bin**. Then download the most recent version of [MinGW](https://www.mingw-w64.org/docs/overview/), and especially the **mingw-get-setup.exe** which is an *automated GUI installer assistant*. After the new version is installed successfully, update the environment variable by adding **C:\\MinGW\\bin** in (Control Panel >> System and Security >> System >> Advanced system settings >> Environment variables >> System variables >> Path >> Edit). Then open a new command prompt (console) and type, 
 
 <br>
 
@@ -364,7 +364,7 @@ A word of caution, If *Rtools* is already installed then make sure that it does 
 
 <br>
 
-*FastRGF* works only with [MinGW-w64](http://mingw-w64.org/doku.php) because only this version provides POSIX threads. It can be downloaded from the project's [official SourceForge page](https://sourceforge.net/projects/mingw-w64/). After a successful download and installation the user should also update the environment variables field in (Control Panel >> System and Security >> System >> Advanced system settings >> Environment variables >> System variables >> Path >> Edit) by adding the following path (assuming the software is installed in **C:\\Program Files (x86)** folder),
+*FastRGF* works only with [MinGW-w64](https://www.mingw-w64.org/docs/overview/) because only this version provides POSIX threads. It can be downloaded from the project's [official SourceForge page](https://sourceforge.net/projects/mingw-w64/). After a successful download and installation the user should also update the environment variables field in (Control Panel >> System and Security >> System >> Advanced system settings >> Environment variables >> System variables >> Path >> Edit) by adding the following path (assuming the software is installed in **C:\\Program Files (x86)** folder),
 
 <br>
 
@@ -566,6 +566,6 @@ Use the following link to report bugs/issues,
 
 If you use the code of this repository in your paper or research please cite both **RGF** and the **original articles / software**:
 
-* [https://cran.r-project.org/web/packages/RGF/citation.html](https://cran.r-project.org/web/packages/RGF/citation.html)
+* [https://CRAN.R-project.org/package=RGF/citation.html](https://CRAN.R-project.org/package=RGF/citation.html)
 
 <br>


### PR DESCRIPTION
this PR includes an '.onAttach' message in the 'package.R' file. It is required for some Operating Systems. I've done the same for all my R packages that utilize the 'reticulate' package and call Python code. For a reference you can see the [issue](https://github.com/mlampros/fuzzywuzzyR/pull/7) in my 'fuzzywuzzyR' package (github repository).