### PR TITLE
Fix R-package CI failures on macOS

### DIFF
--- a/.ci/python_tests.sh
+++ b/.ci/python_tests.sh
@@ -25,7 +25,7 @@ bash miniconda.sh -b -p $CONDA_PATH
 conda config --set always_yes yes --set changeps1 no
 conda update -q conda
 if [[ $TASK == "R_PACKAGE" ]]; then
-  conda create -q -n $CONDA_ENV python=$PYTHON_VERSION pip openssl libffi --no-deps
+  conda create -q -n $CONDA_ENV python=$PYTHON_VERSION pip openssl libffi zlib --no-deps
   source activate $CONDA_ENV
   pip install setuptools joblib numpy scikit-learn scipy pandas wheel
 else


### PR DESCRIPTION
Current `master` branch is failing to load `rgf` Python package via `reticulate` and it results in the following error:
```
...
RGF Coverage: 5.23%
...
Code coverage is extremely small!
```

That error happens only on macOS. I checked and can confirm this is due to that `macos-latest` tag is referring macOS 11 right now while previously it was referring macOS 10.15.

During my investigation I found that `reticulate` cannot load `rgf` Python library due to the following internal error:
```
  ImportError: dlopen(/Users/runner/miniconda/envs/test-env/lib/python3.9/lib-dynload/zlib.cpython-39-darwin.so, 2): Library not loaded: @rpath/libz.1.dylib
  Referenced from: /Users/runner/miniconda/envs/test-env/lib/python3.9/lib-dynload/zlib.cpython-39-darwin.so
  Reason: image not found
```

`zlib` installation fixes this problem.